### PR TITLE
New test library for HAProxy Load-balancers.

### DIFF
--- a/tests/rhui3_tests/test_hap.py
+++ b/tests/rhui3_tests/test_hap.py
@@ -1,0 +1,85 @@
+#! /usr/bin/python -tt
+
+import nose, unittest, stitches, logging, yaml
+
+from rhui3_tests_lib.rhuimanager import *
+from rhui3_tests_lib.rhuimanager_hap import *
+from rhui3_tests_lib.hap import *
+
+logging.basicConfig(level=logging.DEBUG)
+
+connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+
+with open('/tmp/rhui3-tests/tests/rhui3_tests/rhui_manager.yaml', 'r') as file:
+    doc = yaml.load(file)
+
+rhui_login = doc['rhui_login']
+rhui_pass = doc['rhui_pass']
+
+def test_01_initial_run():
+    '''
+        log in to RHUI
+        see roles/tests/tasks/main.yml
+    '''
+    RHUIManager.initial_run(connection, username  = rhui_login, password = rhui_pass)
+
+def test_02_list_empty_hap():
+    '''
+        check if there are no HAProxy Load-balancers
+    '''
+    hap_list = RHUIManagerHap.list(connection)
+    nose.tools.assert_equal(hap_list, [])
+
+def test_03_add_hap():
+    '''
+        add an HAProxy Load-balancer
+    '''
+    hap_list = RHUIManagerHap.list(connection)
+    nose.tools.assert_equal(hap_list, [])
+    hap = Hap()
+    RHUIManagerHap.add_hap(connection, hap)
+
+
+def test_04_list_hap():
+    '''
+        check if the HAProxy Load-balancer was added
+    '''
+    hap_list = RHUIManagerHap.list(connection)
+    nose.tools.assert_not_equal(hap_list, [])
+
+
+def test_05_readd_hap():
+    '''
+        add the HAProxy Load-balancer again (reapply the configuration)
+    '''
+    hap_list = RHUIManagerHap.list(connection)
+    nose.tools.assert_not_equal(hap_list, [])
+    hap = Hap()
+    RHUIManagerHap.add_hap(connection, hap, update=True)
+
+
+def test_06_list_hap():
+    '''
+        check if the HAProxy Load-balancer is still tracked
+    '''
+    hap_list = RHUIManagerHap.list(connection)
+    nose.tools.assert_not_equal(hap_list, [])
+
+
+def test_07_delete_hap():
+    '''
+        delete the HAProxy Load-balancer
+    '''
+    hap = Hap()
+    RHUIManagerHap.delete_haps(connection, hap)
+    hap_list = RHUIManagerHap.list(connection)
+    nose.tools.assert_equal(hap_list, [])
+
+
+def test_08_list_hap():
+    '''
+        list HAProxy Load-balancers again, expect none
+    '''
+    hap_list = RHUIManagerHap.list(connection)
+    nose.tools.assert_equal(hap_list, [])
+

--- a/tests/rhui3_tests_lib/hap.py
+++ b/tests/rhui3_tests_lib/hap.py
@@ -1,0 +1,41 @@
+""" Hap container """
+import re
+import screenitem
+import lineparser
+
+class Hap(screenitem.ScreenItem):
+    """An HAP attributes container"""
+    parser = lineparser.Parser(mapping=[
+            ('host_name', re.compile("^  Hostname:\s*(.*)$")),
+            ('user_name', re.compile("^  SSH Username:\s*(.*)$")),
+            ('ssh_key_path', re.compile("^  SSH Private Key:\s*(.*)$")),
+    ])
+
+    def __init__(self,
+            host_name="hap01.example.com",
+            user_name="ec2-user",
+            ssh_key_path="/root/.ssh/id_rsa_rhua",
+        ):
+        self.host_name = host_name
+        self.user_name = user_name
+        self.ssh_key_path = ssh_key_path
+
+    def __repr__(self):
+        return "Hap(" + \
+                "host_name=%r, " % self.host_name + \
+                "user_name=%r, " % self.user_name + \
+                "ssh_key_path=%r)" % self.ssh_key_path
+
+    def __eq__(self, other):
+        ret = True
+        ret &= self.host_name == other.host_name
+        ret &= self.user_name == other.user_name
+        ret &= self.ssh_key_path == other.ssh_key_path
+        return ret
+
+    def __cmp__(self, other):
+        """for comparison of sorted lists to work as expected"""
+        if self == other:
+            return 0
+        # hack that in other cases
+        return cmp(repr(self), repr(other))

--- a/tests/rhui3_tests_lib/rhuimanager.py
+++ b/tests/rhui3_tests_lib/rhuimanager.py
@@ -135,14 +135,12 @@ class RHUIManager(object):
         '''
         Open specified rhui-manager screen
         '''
-        if screen_name in ["repo", "cds", "sync", "identity", "users"]:
+        if screen_name in ["repo", "cds", "loadbalancers", "sync", "identity", "users"]:
             key = screen_name[:1]
         elif screen_name == "client":
             key = "e"
         elif screen_name == "entitlements":
             key = "n"
-        elif screen_name == "haproxy":
-            key = "l"
         Expect.enter(connection, key)
         Expect.expect(connection, "rhui \(" + screen_name + "\) =>")
 

--- a/tests/rhui3_tests_lib/rhuimanager_hap.py
+++ b/tests/rhui3_tests_lib/rhuimanager_hap.py
@@ -1,0 +1,97 @@
+""" RHUIManager HAP functions """
+
+import re
+
+from stitches.expect import Expect, ExpectFailed, CTRL_C
+from rhui3_tests_lib.rhuimanager import RHUIManager, PROCEED_PATTERN
+from rhui3_tests_lib.hap import Hap
+
+class HapAlreadyExistsError(ExpectFailed):
+    """
+    To be raised when trying to add an already tracked Hap
+    """
+
+class NoSuchHap(ExpectFailed):
+    """
+    To be raised e.g. when trying to select a non-existing Hap
+    """
+
+class InvalidSshKeyPath(ExpectFailed):
+    """
+    To be raised if rhui-manager wasn't able to locate the provided SSH key path
+    """
+
+class RHUIManagerHap(object):
+    '''
+    Represents -= Load-balancer (HAProxy) Management =- RHUI screen
+    '''
+    prompt = 'rhui \(loadbalancers\) => '
+
+    @staticmethod
+    def add_hap(connection, hap=Hap(), update=False):
+        '''
+        Register (add) a new HAP instance
+        @param hap: rhuilib.hap.Hap instance
+        @param update: Bool; update the hap if it is already tracked or raise ExpectFailed
+        '''
+        
+        RHUIManager.screen(connection, "loadbalancers")
+        Expect.enter(connection, "a")
+        Expect.expect(connection, ".*Hostname of the HAProxy Load-balancer instance to register:")
+        Expect.enter(connection, hap.host_name)
+        state = Expect.expect_list(connection, [ \
+            (re.compile(".*Username with SSH access to %s and sudo privileges:.*" % hap.host_name, re.DOTALL), 1),
+            (re.compile(".*A HAProxy Load-balancer instance with that hostname exists.*Continue\?\s+\(y/n\): ", re.DOTALL), 2)
+        ])
+        if state == 2:
+            # hap of the same hostname is already being tracked
+            if not update:
+                # but we don't wish to update its config: raise
+                raise ExpectFailed("%s already tracked but update wasn't required" % hap.host_name)
+            else:
+                # we wish to update, send 'y' answer
+                Expect.enter(connection, "y")
+                # the question about user name comes now
+                Expect.expect(connection, "Username with SSH access to %s and sudo privileges:" % hap.host_name)
+        # if the execution reaches here, uesername question was already asked
+        Expect.enter(connection, hap.user_name)
+        Expect.expect(connection, "Absolute path to an SSH private key to log into %s as %s:" % (hap.host_name, hap.user_name))
+        Expect.enter(connection, hap.ssh_key_path)
+        state = Expect.expect_list(connection, [
+            (re.compile(".*Cannot find file, please enter a valid path.*", re.DOTALL), 1),
+            (PROCEED_PATTERN, 2)
+        ])
+        if state == 1:
+            # don't know how to continue with invalid path: raise
+            Expect.enter(connection, CTRL_C)
+            Expect.enter(connection, "q")
+            raise InvalidSshKeyPath(hap.ssh_key_path)
+        # all OK, confirm
+        Expect.enter(connection, "y")
+        # some installation and configuration through Puppet happens here, let it take its time
+        Expect.expect(connection, "The HAProxy Load-balancer was successfully configured." + ".*rhui \(.*\) =>", 180)
+
+
+    @staticmethod
+    def delete_haps(connection, *hapes):
+        '''
+        unregister (delete) HAP instance from the RHUI
+        '''
+        RHUIManager.screen(connection, "loadbalancers")
+        Expect.enter(connection, "d")
+        RHUIManager.select_items(connection, *hapes)
+        Expect.enter(connection, "y")
+        Expect.expect(connection, "Unregistered" + ".*rhui \(.*\) =>", 180)
+
+    @staticmethod
+    def list(connection):
+        '''
+        return the list of currently managed HAPs
+        '''
+        RHUIManager.screen(connection, "loadbalancers")
+        # eating prompt!!
+        lines = RHUIManager.list_lines(connection, prompt=RHUIManagerHap.prompt)
+        ret = Hap.parse(lines)
+        return [hap for _, hap in ret]
+
+


### PR DESCRIPTION
Initial version. Successfully tested on RHEL 6 and 7 with the following output:

```
[root@ip-10-101-9-115 rhui3-tests]# nosetests -vs -l DEBUG tests/rhui3_tests/test_hap.py 
log in to RHUI ... ok
check if there are no HAProxy Load-balancers ... ok
add an HAProxy Load-balancer ... ok
check if the HAProxy Load-balancer was added ... ok
add the HAProxy Load-balancer again (reapply the configuration) ... ok
check if the HAProxy Load-balancer is still tracked ... ok
delete the HAProxy Load-balancer ... ok
list HAProxy Load-balancers again, expect none ... ok

----------------------------------------------------------------------
Ran 8 tests in 43.709s

OK
```