### PR TITLE
RH repo lib and tests

### DIFF
--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -4,7 +4,6 @@ import nose, unittest, stitches, logging, yaml
 
 from rhui3_tests_lib.rhuimanager import *
 from rhui3_tests_lib.rhuimanager_repo import *
-from os.path import basename
 
 from os.path import basename
 

--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -27,7 +27,7 @@ def test_01_repo_setup():
     RHUIManager.initial_run(connection, username = rhui_login, password = rhui_pass)
 
 def test_02_check_empty_repo_list():
-    '''Check the repolist is empty'''
+    '''Check if the repolist is empty'''
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def test_03_create_3_custom_repos():
@@ -37,11 +37,11 @@ def test_03_create_3_custom_repos():
     RHUIManagerRepo.add_custom_repo(connection, "custom-i386-i386", "", "custom/i386/i386", "1", "y", "", "n" )
 
 def test_04_check_custom_repo_list():
-    '''Check the repolist contains 3 custom repos'''
+    '''Check if the repolist contains 3 custom repos'''
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), ['custom-i386-i386', 'custom-i386-x86_64', 'custom-x86_64-x86_64'])
 
 def test_05_repo_id_uniqness():
-    '''Check that repo id should be unique'''
+    '''Check that repo id is unique'''
     RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
 
 def test_06_upload_rpm_to_custom_repo():
@@ -55,17 +55,17 @@ def test_07_remove_3_custom_repos():
 
 def test_08_add_rh_repo_by_repository():
     '''Add a RH repo by repository'''
-    RHUIManagerRepo.add_rh_repo_by_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\) \(Yum\)"])
+    RHUIManagerRepo.add_rh_repo_by_repo(connection, ["Red Hat Update Infrastructure 2(.0)? \(RPMs\).*"])
     nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
 def test_09_delete_one_repo():
     '''Remove a RH repo'''
-    RHUIManagerRepo.delete_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\)"])
+    RHUIManagerRepo.delete_repo(connection, ["Red Hat Update Infrastructure 2(.0)? \(RPMs\).*"])
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def test_10_add_rh_repo_by_product():
     '''Add a RH repo by product'''
-    RHUIManagerRepo.add_rh_repo_by_product(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\)"])
+    RHUIManagerRepo.add_rh_repo_by_product(connection, ["Red Hat Update Infrastructure 2(.0)? \(RPMs\)"])
     nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
 def test_11_delete_repo():
@@ -80,6 +80,16 @@ def test_12_add_all_rh_repos():
 
 def test_13_delete_all_repos():
     '''Delete all repositories from RHUI'''
+    RHUIManagerRepo.delete_all_repos(connection)
+    nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+
+def test_14_add_docker_container():
+    '''Add a RH docker container'''
+    RHUIManagerRepo.add_docker_container(connection, "rhcertification/redhat-certification", "", "RH Certification Docker")
+    nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
+
+def test_15_delete_docker_container():
+    '''Delete a docker container'''
     RHUIManagerRepo.delete_all_repos(connection)
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 

--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -4,6 +4,7 @@ import nose, unittest, stitches, logging, yaml
 
 from rhui3_tests_lib.rhuimanager import *
 from rhui3_tests_lib.rhuimanager_repo import *
+from os.path import basename
 
 from os.path import basename
 
@@ -31,10 +32,10 @@ def test_02_check_empty_repo_list():
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def test_03_create_3_custom_repos():
-    '''Create custom repos '''
+    '''Create 3 custom repos (protected, unprotected, no RH GPG check) '''
     RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
-    RHUIManagerRepo.add_custom_repo(connection, "custom-x86_64-x86_64", "", "custom/x86_64/x86_64", "1", "y")
-    RHUIManagerRepo.add_custom_repo(connection, "custom-i386-i386", "", "custom/i386/i386", "1", "y")
+    RHUIManagerRepo.add_custom_repo(connection, "custom-x86_64-x86_64", "", "custom/x86_64/x86_64", "1", "n")
+    RHUIManagerRepo.add_custom_repo(connection, "custom-i386-i386", "", "custom/i386/i386", "1", "y", "", "n" )
 
 def test_04_check_custom_repo_list():
     '''Check the repolist contains 3 custom repos'''
@@ -45,7 +46,7 @@ def test_05_repo_id_uniqness():
     RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
 
 def test_06_upload_rpm_to_custom_repo():
-    '''Upload content to custom repo'''
+    '''Upload content to the custom repo'''
     RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files")
 
 def test_07_remove_3_custom_repos():
@@ -54,7 +55,7 @@ def test_07_remove_3_custom_repos():
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def test_08_add_rh_repo_by_repository():
-    '''Add a RH repo'''
+    '''Add a RH repo by repository'''
     RHUIManagerRepo.add_rh_repo_by_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\) \(Yum\)"])
     nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
@@ -63,15 +64,24 @@ def test_09_delete_one_repo():
     RHUIManagerRepo.delete_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\)"])
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-def test_10_add_all_rh_repos():
+def test_10_add_rh_repo_by_product():
+    '''Add a RH repo by product'''
+    RHUIManagerRepo.add_rh_repo_by_product(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\)"])
+    nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
+
+def test_11_delete_repo():
+    '''Remove a RH repo'''
+    RHUIManagerRepo.delete_all_repos(connection)
+    nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+
+def test_12_add_all_rh_repos():
      '''Add all RH repos'''
      RHUIManagerRepo.add_rh_repo_all(connection)
+     nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
-def test_11_delete_all_repos():
+def test_13_delete_all_repos():
     '''Delete all repositories from RHUI'''
     RHUIManagerRepo.delete_all_repos(connection)
-
-def test_11_check_empty_repo_list():
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def tearDown():

--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -30,7 +30,7 @@ def test_02_check_empty_repo_list():
     '''Check the repolist is empty'''
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-def test_03_create_repo():
+def test_03_create_3_custom_repos():
     '''Create custom repos '''
     RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
     RHUIManagerRepo.add_custom_repo(connection, "custom-x86_64-x86_64", "", "custom/x86_64/x86_64", "1", "y")
@@ -48,9 +48,30 @@ def test_06_upload_rpm_to_custom_repo():
     '''Upload content to custom repo'''
     RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files")
 
-def test_cleanup():
+def test_07_remove_3_custom_repos():
     '''Remove 3 custom repos'''
     RHUIManagerRepo.delete_repo(connection, ["custom-i386-x86_64", "custom-x86_64-x86_64", "custom-i386-i386"])
+    nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+
+def test_08_add_rh_repo_by_repository():
+    '''Add a RH repo'''
+    RHUIManagerRepo.add_rh_repo_by_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\) \(Yum\)"])
+    nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
+
+def test_09_delete_one_repo():
+    '''Remove a RH repo'''
+    RHUIManagerRepo.delete_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\)"])
+    nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+
+def test_10_add_all_rh_repos():
+     '''Add all RH repos'''
+     RHUIManagerRepo.add_rh_repo_all(connection)
+
+def test_11_delete_all_repos():
+    '''Delete all repositories from RHUI'''
+    RHUIManagerRepo.delete_all_repos(connection)
+
+def test_11_check_empty_repo_list():
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def tearDown():

--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -76,7 +76,7 @@ def test_11_delete_repo():
 def test_12_add_all_rh_repos():
      '''Add all RH repos'''
      RHUIManagerRepo.add_rh_repo_all(connection)
-     nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
+     #nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
 def test_13_delete_all_repos():
     '''Delete all repositories from RHUI'''

--- a/tests/rhui3_tests_lib/rhuimanager.py
+++ b/tests/rhui3_tests_lib/rhuimanager.py
@@ -79,6 +79,16 @@ class RHUIManager(object):
         Expect.enter(connection, match[0])
 
     @staticmethod
+    def select_all(connection):
+        '''
+        Select all items
+        '''
+        Expect.expect(connection, "Enter value .*:")
+        Expect.enter(connection, "a")
+        Expect.expect(connection, "Enter value .*:")
+        Expect.enter(connection, "c")
+
+    @staticmethod
     def quit(connection, prefix="", timeout=10):
         '''
         Quit from rhui-manager

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -84,6 +84,51 @@ class RHUIManagerRepo(object):
             Expect.expect(connection, "rhui \(" + "repo" + "\) =>")
 
     @staticmethod
+    def add_rh_repo_all(connection):
+        '''
+        add a new Red Hat content repository (All in Certificate)
+        '''
+        RHUIManager.screen(connection, "repo")
+        Expect.enter(connection, "a")
+        Expect.expect(connection, "Import Repositories:.*to abort:", 360)
+        Expect.enter(connection, "1")
+        RHUIManager.proceed_without_check(connection)
+        Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>", 180)
+
+    @staticmethod
+    def add_rh_repo_by_product(connection, productlist):
+        '''
+        add a new Red Hat content repository (By Product)
+        '''
+        RHUIManager.screen(connection, "repo")
+        Expect.enter(connection, "a")
+        Expect.expect(connection, "Import Repositories:.*to abort:", 180)
+        Expect.enter(connection, "2")
+        RHUIManager.select(connection, productlist)
+        RHUIManager.proceed_without_check(connection)
+        RHUIManager.quit(connection, "Content will not be downloaded", 45)
+        Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>")
+
+    @staticmethod
+    def add_rh_repo_by_repo(connection, repolist):
+        '''
+        add a new Red Hat content repository (By Repository)
+        '''
+        RHUIManager.screen(connection, "repo")
+        Expect.enter(connection, "a")
+        Expect.expect(connection, "Import Repositories:.*to abort:", 180)
+        Expect.enter(connection, "3")
+        RHUIManager.select(connection, repolist)
+        repocheck = list(repolist)
+        for repo in repolist:
+            #adding repo titles to check list
+            repotitle = re.sub(" \\\\\([^\(]*\\\\\)$", "", repo)
+            if not repotitle in repocheck:
+                repocheck.append(repotitle)
+        RHUIManager.proceed_without_check(connection)
+        Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>")
+
+    @staticmethod
     def list(connection):
         ''' 
         list repositories
@@ -119,6 +164,20 @@ class RHUIManagerRepo(object):
         RHUIManager.select(connection, repolist)
         RHUIManager.proceed_with_check(connection, "The following repositories will be deleted:", repolist, ["Red Hat Repositories", "Custom Repositories"])
         Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>")
+
+    @staticmethod
+    def delete_all_repos(connection):
+        '''
+        delete all repositories from the RHUI
+        '''
+        RHUIManager.screen(connection, "repo")
+        Expect.enter(connection, "d")
+        Expect.expect(connection, "Enter value .*:", 360)
+        Expect.enter(connection, "a")
+        Expect.expect(connection, "Enter value .*:")
+        Expect.enter(connection, "c")
+        RHUIManager.proceed_without_check(connection)
+        Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>", 360)
 
     @staticmethod
     def upload_content(connection, repolist, path):

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -90,7 +90,7 @@ class RHUIManagerRepo(object):
         '''
         RHUIManager.screen(connection, "repo")
         Expect.enter(connection, "a")
-        Expect.expect(connection, "Import Repositories:.*to abort:", 180)
+        Expect.expect(connection, "Import Repositories:.*to abort:", 660)
         Expect.enter(connection, "1")
         RHUIManager.proceed_without_check(connection)
         Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>", 180)
@@ -102,7 +102,7 @@ class RHUIManagerRepo(object):
         '''
         RHUIManager.screen(connection, "repo")
         Expect.enter(connection, "a")
-        Expect.expect(connection, "Import Repositories:.*to abort:", 180)
+        Expect.expect(connection, "Import Repositories:.*to abort:", 660)
         Expect.enter(connection, "2")
         RHUIManager.select(connection, productlist)
         RHUIManager.proceed_without_check(connection)
@@ -115,7 +115,7 @@ class RHUIManagerRepo(object):
         '''
         RHUIManager.screen(connection, "repo")
         Expect.enter(connection, "a")
-        Expect.expect(connection, "Import Repositories:.*to abort:", 180)
+        Expect.expect(connection, "Import Repositories:.*to abort:", 660)
         Expect.enter(connection, "3")
         RHUIManager.select(connection, repolist)
         repocheck = list(repolist)
@@ -124,6 +124,22 @@ class RHUIManagerRepo(object):
             repotitle = re.sub(" \\\\\([^\(]*\\\\\)$", "", repo)
             if not repotitle in repocheck:
                 repocheck.append(repotitle)
+        RHUIManager.proceed_without_check(connection)
+        Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>")
+
+    @staticmethod
+    def add_docker_container(connection, containername, containerid="", displayname=""):
+        '''
+        add a new Red Hat docker container
+        '''
+        RHUIManager.screen(connection, "repo")
+        Expect.enter(connection, "ad")
+        Expect.expect(connection, "Name of the container in the registry:")
+        Expect.enter(connection, containername)
+        Expect.expect(connection, "Unique ID for the container .*]", 60)
+        Expect.enter(connection, containerid)
+        Expect.expect(connection, "Display name for the container.*]:")
+        Expect.enter(connection, displayname)
         RHUIManager.proceed_without_check(connection)
         Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>")
 
@@ -161,7 +177,7 @@ class RHUIManagerRepo(object):
         RHUIManager.screen(connection, "repo")
         Expect.enter(connection, "d")
         RHUIManager.select(connection, repolist)
-        RHUIManager.proceed_with_check(connection, "The following repositories will be deleted:", repolist, ["Red Hat Repositories", "Custom Repositories"])
+        RHUIManager.proceed_without_check(connection)
         Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>")
 
     @staticmethod

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -90,7 +90,7 @@ class RHUIManagerRepo(object):
         '''
         RHUIManager.screen(connection, "repo")
         Expect.enter(connection, "a")
-        Expect.expect(connection, "Import Repositories:.*to abort:", 360)
+        Expect.expect(connection, "Import Repositories:.*to abort:", 180)
         Expect.enter(connection, "1")
         RHUIManager.proceed_without_check(connection)
         Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>", 180)
@@ -106,7 +106,6 @@ class RHUIManagerRepo(object):
         Expect.enter(connection, "2")
         RHUIManager.select(connection, productlist)
         RHUIManager.proceed_without_check(connection)
-        RHUIManager.quit(connection, "Content will not be downloaded", 45)
         Expect.expect(connection, ".*rhui \(" + "repo" + "\) =>")
 
     @staticmethod
@@ -191,4 +190,3 @@ class RHUIManagerRepo(object):
         Expect.enter(connection, path)
         RHUIManager.proceed_without_check(connection)
         Expect.expect(connection, "rhui \(" + "repo" + "\) =>")
-


### PR DESCRIPTION
On RHEL7: 

nosetests -vs tests/rhui3_tests/test_repo_managment.py
*** Running test_repo_managment.py: *** 
Do initial rhui-manager run ... ok
Check the repolist is empty ... ok
Create 3 custom repos (protected, unprotected, RH GPG check) ... ok
Check the repolist contains 3 custom repos ... ok
Check that repo id should be unique ... ok
Upload content to the custom repo ... ok
Remove 3 custom repos ... ok
Add a RH repo by repository ... ok
Remove a RH repo ... ok
Add a RH repo by product ... ok
Remove a RH repo ... ok
Add all RH repos ... ok
Delete all repositories from RHUI ... ok
*** Finished running test_repo_managment.py. *** 

----------------------------------------------------------------------
Ran 13 tests in 747.673s

On RHEL6 the last test will fail because of [BZ1391641](https://bugzilla.redhat.com/show_bug.cgi?id=1391641).