### PR TITLE
Client entitlement and rpm lib and some tests

### DIFF
--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -1,0 +1,66 @@
+import nose, unittest, stitches, logging, yaml
+
+from rhui3_tests_lib.rhuimanager_cli import *
+from rhui3_tests_lib.rhuimanager_repo import *
+
+from os.path import basename
+
+logging.basicConfig(level=logging.DEBUG)
+
+connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+
+with open('/tmp/rhui3-tests/tests/rhui3_tests/rhui_manager.yaml', 'r') as file:
+    doc = yaml.load(file)
+
+rhui_login = doc['rhui_login']
+rhui_pass = doc['rhui_pass']
+
+def setUp():
+    print "*** Running %s: *** " % basename(__file__)
+
+def test_01_repo_setup():
+    '''do initial rhui-manager run'''
+    RHUIManager.initial_run(connection, username = rhui_login, password = rhui_pass)
+
+def test_02_add_repos():
+    '''
+       add a custom and RH content repos to protect by a client entitlement certificate
+    '''
+    RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
+    RHUIManagerRepo.add_rh_repo_by_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\).*"])
+
+def test_02_generate_ent_cert():
+    '''
+       generate an entitlement certificate
+    '''
+    Expect.enter(connection, "home")
+    Expect.expect(connection, ".*rhui \(" + "home" + "\) =>")
+    RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", "Red Hat Update Infrastructure 2.0 \(RPMs\)"], "test_ent_cli", "/root/")
+    Expect.enter(connection, 'q')
+    Expect.ping_pong(connection, "test -f /root/test_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
+    Expect.ping_pong(connection, "test -f /root/test_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
+
+def test_02_create_cli_rpm():
+    '''
+       create a client configuration RPM from an entitlement certificate
+    '''
+    RHUIManager.initial_run(connection, username = rhui_login, password = rhui_pass)
+    RHUIManagerClient.create_conf_rpm(connection, "/root", "/root/test_ent_cli.crt", "/root/test_ent_cli.key", "test_cli_rpm", "3.0")
+    Expect.enter(connection, 'q')
+    Expect.ping_pong(connection, "test -f /root/test_cli_rpm-3.0/build/RPMS/noarch/test_cli_rpm-3.0-1.noarch.rpm && echo SUCCESS", "[^ ]SUCCESS")
+
+def test_03_cleanup():
+    '''
+       remove created repos, entitlement and custom cli rpm
+    '''
+    RHUIManager.initial_run(connection, username = rhui_login, password = rhui_pass)
+    RHUIManagerRepo.delete_all_repos(connection)
+    nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+    Expect.enter(connection, 'q')
+    Expect.ping_pong(connection, "rm -f /root/test_ent_cli.* && echo SUCCESS", "[^ ]SUCCESS")
+    Expect.ping_pong(connection, "rm -rf /root/test_cli_rpm-3.0/ && echo SUCCESS", "[^ ]SUCCESS")
+    RHUIManager.initial_run(connection, username = rhui_login, password = rhui_pass)
+
+def tearDown():
+    print "*** Finished running %s. *** " % basename(__file__)
+

--- a/tests/rhui3_tests_lib/rhuimanager_cli.py
+++ b/tests/rhui3_tests_lib/rhuimanager_cli.py
@@ -1,0 +1,50 @@
+""" RHUIManager Client functions """
+
+from stitches.expect import Expect
+from rhui3_tests_lib.rhuimanager import RHUIManager
+
+
+class RHUIManagerClient(object):
+    '''
+    Represents -= Client Entitlement Management =- RHUI screen
+    '''
+    @staticmethod
+    def generate_ent_cert(connection, repolist, certname, dirname, validity_days="", cert_pw=None):
+        '''
+        generate an entitlement certificate
+        '''
+        RHUIManager.screen(connection, "client")
+        Expect.enter(connection, "e")
+        RHUIManager.select(connection, repolist)
+        Expect.expect(connection, "Name of the certificate.*contained with it:")
+        Expect.enter(connection, certname)
+        Expect.expect(connection, "Local directory in which to save the generated certificate.*:")
+        Expect.enter(connection, dirname)
+        Expect.expect(connection, "Number of days the certificate should be valid.*:")
+        Expect.enter(connection, validity_days)
+        RHUIManager.proceed_without_check(connection)
+        Expect.expect(connection, ".*rhui \(" + "client" + "\) =>")
+
+    @staticmethod
+    def create_conf_rpm(connection, dirname, certpath, certkey, rpmname, rpmversion="", dockerport="", unprotected_repos=None):
+        '''
+        create a client configuration RPM from an entitlement certificate
+        '''
+        RHUIManager.screen(connection, "client")
+        Expect.enter(connection, "c")
+        Expect.expect(connection, "Full path to local directory.*:")
+        Expect.enter(connection, dirname)
+        Expect.expect(connection, "Name of the RPM:")
+        Expect.enter(connection, rpmname)
+        Expect.expect(connection, "Version of the configuration RPM.*:")
+        Expect.enter(connection, rpmversion)
+        Expect.expect(connection, "Full path to the entitlement certificate.*:")
+        Expect.enter(connection, certpath)
+        Expect.expect(connection, "Full path to the private key for the above entitlement certificate:")
+        Expect.enter(connection, certkey)
+        Expect.expect(connection, "Port to serve Docker content on .*:")
+        Expect.enter(connection, dockerport)
+        if unprotected_repos:
+            RHUIManager.select(connection, unprotected_repos)
+        Expect.expect(connection, ".*rhui \(" + "client" + "\) =>")
+


### PR DESCRIPTION
    *** Running test_client_management.py: ***
    do initial rhui-manager run ... ok
    add a custom and RH content repos to protect by a client entitlement certificate ... ok
    generate an entitlement certificate ... ok
    create a client configuration RPM from an entitlement certificate ... ok
    remove created repos, entitlement and custom cli rpm ... ok
    *** Finished running test_client_management.py. ***
     
    ----------------------------------------------------------------------
    Ran 5 tests in 488.152s
     
    OK