### PR TITLE
Test the creation of a docker config RPM

### DIFF
--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -43,9 +43,18 @@ def test_02_create_cli_rpm():
     Expect.enter(connection, 'q')
     Expect.ping_pong(connection, "test -f /root/test_cli_rpm-3.0/build/RPMS/noarch/test_cli_rpm-3.0-1.noarch.rpm && echo SUCCESS", "[^ ]SUCCESS")
 
-def test_03_cleanup():
+def test_03_create_docker_cli_rpm():
     '''
-       remove created repos, entitlement and custom cli rpm
+       create a docker client configuration RPM
+    '''
+    RHUIManager.initial_run(connection)
+    RHUIManagerClient.create_docker_conf_rpm(connection, "/root", "test_docker_cli_rpm", "4.0")
+    Expect.enter(connection, 'q')
+    Expect.ping_pong(connection, "test -f /root/test_docker_cli_rpm-4.0/build/RPMS/noarch/test_docker_cli_rpm-4.0-1.noarch.rpm && echo SUCCESS", "[^ ]SUCCESS")
+
+def test_04_cleanup():
+    '''
+       remove created repos, entitlement and custom cli rpms
     '''
     RHUIManager.initial_run(connection)
     RHUIManagerRepo.delete_all_repos(connection)
@@ -53,6 +62,7 @@ def test_03_cleanup():
     Expect.enter(connection, 'q')
     Expect.ping_pong(connection, "rm -f /root/test_ent_cli.* && echo SUCCESS", "[^ ]SUCCESS")
     Expect.ping_pong(connection, "rm -rf /root/test_cli_rpm-3.0/ && echo SUCCESS", "[^ ]SUCCESS")
+    Expect.ping_pong(connection, "rm -rf /root/test_docker_cli_rpm-4.0/ && echo SUCCESS", "[^ ]SUCCESS")
     RHUIManager.initial_run(connection)
 
 def tearDown():

--- a/tests/rhui3_tests_lib/rhuimanager_cli.py
+++ b/tests/rhui3_tests_lib/rhuimanager_cli.py
@@ -46,3 +46,19 @@ class RHUIManagerClient(object):
             RHUIManager.select(connection, unprotected_repos)
         Expect.expect(connection, ".*rhui \(" + "client" + "\) =>")
 
+    @staticmethod
+    def create_docker_conf_rpm(connection, dirname, rpmname, rpmversion="", dockerport=""):
+        '''
+        create a client configuration RPM from an entitlement certificate
+        '''
+        RHUIManager.screen(connection, "client")
+        Expect.enter(connection, "d")
+        Expect.expect(connection, "Full path to local directory.*:")
+        Expect.enter(connection, dirname)
+        Expect.expect(connection, "Name of the RPM:")
+        Expect.enter(connection, rpmname)
+        Expect.expect(connection, "Version of the configuration RPM.*:")
+        Expect.enter(connection, rpmversion)
+        Expect.expect(connection, "Port to serve Docker content on .*:")
+        Expect.enter(connection, dockerport)
+        Expect.expect(connection, ".*rhui \(" + "client" + "\) =>")


### PR DESCRIPTION
...which was split from the yum config RPM. The creation (and deletion) of the RPM is tested as part of test_client_management.py right after testing the creation of a yum-based client config RPM.

Checked on RHEL 6 and 7 with the following output:

```
*** Running test_client_management.py: *** 
do initial rhui-manager run ... ok
add a custom and RH content repos to protect by a client entitlement certificate ... ok
generate an entitlement certificate ... ok
create a client configuration RPM from an entitlement certificate ... ok
create a docker client configuration RPM ... ok
remove created repos, entitlement and custom cli rpms ... ok
*** Finished running test_client_management.py. *** 

----------------------------------------------------------------------
Ran 6 tests in 398.759s

OK
```
