### PR TITLE
Inspect also custom entitlements when a custom repo exists.

### DIFF
--- a/tests/rhui3_tests/test_entitlements.py
+++ b/tests/rhui3_tests/test_entitlements.py
@@ -74,5 +74,13 @@ def test_08_remove_custom_repo():
     RHUIManagerRepo.delete_repo(connection, ["custom-enttest"])
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
+def test_09_list_custom_entitlements():
+    '''
+       list custom content certificate entitlements, expect none
+    '''
+    Expect.enter(connection, "home")
+    list = RHUIManagerEntitlements.list_custom_entitlements(connection)
+    nose.tools.assert_equal(len(list), 0)
+
 def tearDown():
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_entitlements.py
+++ b/tests/rhui3_tests/test_entitlements.py
@@ -4,6 +4,7 @@ import nose, unittest, stitches, logging, yaml
 
 from rhui3_tests_lib.rhuimanager import *
 from rhui3_tests_lib.rhuimanager_entitlement import *
+from rhui3_tests_lib.rhuimanager_repo import *
 
 from os.path import basename
 
@@ -30,7 +31,7 @@ def test_02_list_rh_entitlements():
 
 def test_03_list_custom_entitlements():
     '''
-       list custom content certificate entitlements
+       list custom content certificate entitlements, expect none
     '''
     list = RHUIManagerEntitlements.list_custom_entitlements(connection)
     nose.tools.assert_equal(len(list), 0)
@@ -42,12 +43,36 @@ def test_04_upload_rh_certificate():
     list = RHUIManagerEntitlements.upload_rh_certificate(connection)
     nose.tools.assert_not_equal(len(list), 0)
 
-def test_02_list_rh_entitlements():
+def test_05_list_rh_entitlements():
     '''
        list Red Hat content certificate entitlements
     '''
     entitlements = RHUIManagerEntitlements.list_rh_entitlements(connection)
     nose.tools.eq_(isinstance(entitlements, list), True)
+
+def test_06_add_custom_repo():
+    '''
+       add a custom repo to protect by a client entitlement certificate
+    '''
+    Expect.enter(connection, "home")
+    Expect.expect(connection, ".*rhui \(" + "home" + "\) =>")
+    RHUIManagerRepo.add_custom_repo(connection, "custom-enttest", "", "", "1", "y")
+
+def test_07_list_custom_entitlements():
+    '''
+       list custom content certificate entitlements, expect one
+    '''
+    list = RHUIManagerEntitlements.list_custom_entitlements(connection)
+    nose.tools.assert_equal(len(list), 1)
+
+def test_08_remove_custom_repo():
+    '''
+       remove the custom repo
+    '''
+    Expect.enter(connection, "home")
+    Expect.expect(connection, ".*rhui \(" + "home" + "\) =>")
+    RHUIManagerRepo.delete_repo(connection, ["custom-enttest"])
+    nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def tearDown():
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests_lib/rhuimanager_entitlement.py
+++ b/tests/rhui3_tests_lib/rhuimanager_entitlement.py
@@ -57,7 +57,7 @@ class RHUIManagerEntitlements(object):
         
         repo_list = []
         
-        for line in match.split("\n"):
+        for line in match.splitlines():
             if "Name:" in line:
                 repo_list.append(line.replace("Name:", "").strip())
         return sorted(repo_list)


### PR DESCRIPTION
This commit enables the entitlements test case to check whether rhui-manager actually lists a custom repository entitlement when a custom repository protected by an entitlement exists.

Output:

```
*** Running test_entitlements.py: *** 
log in into RHUI ... ok
list Red Hat content certificate entitlements ... ok
list custom content certificate entitlements, expect none ... ok
upload a new or updated Red Hat content certificate ... ok
list Red Hat content certificate entitlements ... ok
add a custom repo to protect by a client entitlement certificate ... ok
list custom content certificate entitlements, expect one ... ok
remove the custom repo ... ok
*** Finished running test_entitlements.py. *** 

----------------------------------------------------------------------
Ran 8 tests in 26.568s

OK
```

PS. There are also some cosmetic changes in the library and the test case: from `split("\n")` to `splitlines()` as that's cleaner python, natural numbering of the test cases, and different labels for "no custom entitlements" vs. "one custom entitlement".