### PR TITLE
Library function and test case for atomic client configuration package.

### DIFF
--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -101,6 +101,7 @@ def test_99_cleanup():
     Expect.ping_pong(connection, "rm -rf /root/test_cli_rpm-3.0/ && echo SUCCESS", "[^ ]SUCCESS")
     Expect.ping_pong(connection, "rm -rf /root/test_docker_cli_rpm-4.0/ && echo SUCCESS", "[^ ]SUCCESS")
     if not oldrhel:
+        Expect.ping_pong(connection, "rm -f /root/test_atomic_ent_cli* && echo SUCCESS", "[^ ]SUCCESS")
         Expect.ping_pong(connection, "rm -f /root/test_atomic_pkg.tar.gz && echo SUCCESS", "[^ ]SUCCESS")
     RHUIManager.initial_run(connection)
 

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -5,9 +5,9 @@ from rhui3_tests_lib.rhuimanager_repo import *
 
 from os.path import basename
 
-# The parts related to Atomic can be skipped because they only work on RHEL 7; BZ 1405083.
+# The parts related to Atomic are applicable to RHEL 7+ only.
 import platform
-oldrhel = float(platform.linux_distribution()[1]) < 7
+atomic_unsupported = float(platform.linux_distribution()[1]) < 7
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -60,7 +60,7 @@ def test_04_add_atomic_repo():
     '''
        add the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only)
     '''
-    if oldrhel:
+    if atomic_unsupported:
         return
     RHUIManager.initial_run(connection)
     RHUIManagerRepo.add_rh_repo_by_product(connection, ["RHEL RHUI Atomic 7 Ostree Repo"])
@@ -69,7 +69,7 @@ def test_05_generate_atomic_ent_cert():
     '''
        generate an entitlement certificate for the Atomic repo (RHEL 7+ only)
     '''
-    if oldrhel:
+    if atomic_unsupported:
         return
     Expect.enter(connection, "home")
     Expect.expect(connection, ".*rhui \(" + "home" + "\) =>")
@@ -82,7 +82,7 @@ def test_06_create_atomic_pkg():
     '''
        create an Atomic client configuration package (RHEL 7+ only)
     '''
-    if oldrhel:
+    if atomic_unsupported:
         return
     RHUIManager.initial_run(connection)
     RHUIManagerClient.create_atomic_conf_pkg(connection, "/root", "test_atomic_pkg", "/root/test_atomic_ent_cli.crt", "/root/test_atomic_ent_cli.key")
@@ -100,7 +100,7 @@ def test_99_cleanup():
     Expect.ping_pong(connection, "rm -f /root/test_ent_cli.* && echo SUCCESS", "[^ ]SUCCESS")
     Expect.ping_pong(connection, "rm -rf /root/test_cli_rpm-3.0/ && echo SUCCESS", "[^ ]SUCCESS")
     Expect.ping_pong(connection, "rm -rf /root/test_docker_cli_rpm-4.0/ && echo SUCCESS", "[^ ]SUCCESS")
-    if not oldrhel:
+    if not atomic_unsupported:
         Expect.ping_pong(connection, "rm -f /root/test_atomic_ent_cli* && echo SUCCESS", "[^ ]SUCCESS")
         Expect.ping_pong(connection, "rm -f /root/test_atomic_pkg.tar.gz && echo SUCCESS", "[^ ]SUCCESS")
     RHUIManager.initial_run(connection)

--- a/tests/rhui3_tests_lib/rhuimanager_cli.py
+++ b/tests/rhui3_tests_lib/rhuimanager_cli.py
@@ -62,3 +62,22 @@ class RHUIManagerClient(object):
         Expect.expect(connection, "Port to serve Docker content on .*:")
         Expect.enter(connection, dockerport)
         Expect.expect(connection, ".*rhui \(" + "client" + "\) =>")
+
+    @staticmethod
+    def create_atomic_conf_pkg(connection, dirname, tarname, certpath, certkey, dockerport=""):
+        '''
+        create an atomic client configuration package (RHEL 7+ only)
+        '''
+        RHUIManager.screen(connection, "client")
+        Expect.enter(connection, "o")
+        Expect.expect(connection, "Full path to local directory.*:")
+        Expect.enter(connection, dirname)
+        Expect.expect(connection, "Name of the tar file.*:")
+        Expect.enter(connection, tarname)
+        Expect.expect(connection, "Full path to the entitlement certificate.*:")
+        Expect.enter(connection, certpath)
+        Expect.expect(connection, "Full path to the private key.*:")
+        Expect.enter(connection, certkey)
+        Expect.expect(connection, "Port to serve Docker content on .*:")
+        Expect.enter(connection, dockerport)
+        Expect.expect(connection, ".*rhui \(" + "client" + "\) =>")


### PR DESCRIPTION
Because this option doesn't work on RHEL 6 (and will probably be removed from rhui-manager in the future), the test case checks what version it's running on and skips the setup and test related with Atomic on RHEL < 7. It's done this way because @unittest.skipIf() isn't available on RHEL 6, which uses Python < 2.7.

Output on RHEL 7:

```
*** Running test_client_management.py: *** 
do initial rhui-manager run ... ok
add a custom and RH content repos to protect by a client entitlement certificate ... ok
generate an entitlement certificate ... ok
create a client configuration RPM from an entitlement certificate ... ok
create a docker client configuration RPM ... ok
add the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only) ... ok
generate an entitlement certificate for the Atomic repo (RHEL 7+ only) ... ok
create an Atomic client configuration package (RHEL 7+ only) ... ok
remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+) ... ok
*** Finished running test_client_management.py. *** 

----------------------------------------------------------------------
Ran 9 tests in 740.402s

OK
```

And on RHEL 6 (note that it takes significantly less time (about half as much) to run the tests here; it's because it's not necessary to load the latest entitlements again for the Atomic repo):

```
*** Running test_client_management.py: *** 
do initial rhui-manager run ... ok
add a custom and RH content repos to protect by a client entitlement certificate ... ok
generate an entitlement certificate ... ok
create a client configuration RPM from an entitlement certificate ... ok
create a docker client configuration RPM ... ok
add the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only) ... ok
generate an entitlement certificate for the Atomic repo (RHEL 7+ only) ... ok
create an Atomic client configuration package (RHEL 7+ only) ... ok
remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+) ... ok
*** Finished running test_client_management.py. *** 

----------------------------------------------------------------------
Ran 9 tests in 412.836s

OK
```