### PR TITLE
Delete all test_ent_cli files.

### DIFF
--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -97,7 +97,7 @@ def test_99_cleanup():
     RHUIManagerRepo.delete_all_repos(connection)
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
     Expect.enter(connection, 'q')
-    Expect.ping_pong(connection, "rm -f /root/test_ent_cli.* && echo SUCCESS", "[^ ]SUCCESS")
+    Expect.ping_pong(connection, "rm -f /root/test_ent_cli* && echo SUCCESS", "[^ ]SUCCESS")
     Expect.ping_pong(connection, "rm -rf /root/test_cli_rpm-3.0/ && echo SUCCESS", "[^ ]SUCCESS")
     Expect.ping_pong(connection, "rm -rf /root/test_docker_cli_rpm-4.0/ && echo SUCCESS", "[^ ]SUCCESS")
     if not atomic_unsupported:


### PR DESCRIPTION
When the test entitlement certificate is generated the following files are created in /root:

test_ent_cli.crt  test_ent_cli.csr  test_ent_cli-extensions.txt  test_ent_cli.key

Previously, the cleanup function ran this command to remove the files:

rm -f /root/test_ent_cli.*

Consequently, the test_ent_cli-extensions.txt file was left on the disk. This commit removes the dot from the wildcard. As result, the -extensions.txt file is removed, too.