### PR TITLE
Commented out the forceful termination.

### DIFF
--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -682,5 +682,6 @@ for instance in instances_detail:
 print '# --- instances created ---'
 yaml.dump(result, sys.stdout)
 # miserable hack --- cannot make paramiko not hang upon exit
-import os
-os.system('kill %d' % os.getpid())
+# [revised in February 2017] not necessary anymore
+#import os
+#os.system('kill %d' % os.getpid())


### PR DESCRIPTION
It turns out that the _miserable hack_ isn't needed now. Since it doesn't look very good when you get **Terminated** even though everything is fine, I suggest we get rid of the hack. Let's comment it out in case paramiko starts hanging again sometime in the future and we need to resurrect the hack easily.