### PR TITLE
Setup and testing of Atomic cli, and other refactoring

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -66,14 +66,11 @@ ec2-10.0.0.5.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_b
 [CLI]
 ec2-10.0.0.6.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=/home/USER/.ssh/USER-eu-west-1.pem
 
-#[CLI]
-#10.0.0.7
-
 #[ATOMIC_CLI]
-#10.0.0.8
+#ec2-10.0.0.7.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=/home/USER/.ssh/USER-eu-west-1.pem
 
 #[TEST]
-#ec2-10.0.0.7.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=/home/USER/.ssh/USER-eu-west-1.pem
+#ec2-10.0.0.8.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=/home/USER/.ssh/USER-eu-west-1.pem
 ```
 
 * example 2:

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -28,6 +28,7 @@ Managed roles:
 - Cdses
 - HAProxy (load balancer)
 - Nfs server
+- Cli and Atomic Cli (optional)
 - [Tests](https://github.com/RedHatQE/rhui3-automation/blob/master/tests/README.md) (optional)
 
 Supported configurations
@@ -65,6 +66,12 @@ ec2-10.0.0.5.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_b
 [CLI]
 ec2-10.0.0.6.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=/home/USER/.ssh/USER-eu-west-1.pem
 
+#[CLI]
+#10.0.0.7
+
+#[ATOMIC_CLI]
+#10.0.0.8
+
 #[TEST]
 #ec2-10.0.0.7.eu-west-1.compute.amazonaws.com ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=/home/USER/.ssh/USER-eu-west-1.pem
 ```
@@ -100,7 +107,7 @@ Even though one can apply multiple roles to a single node, some combinations are
 - singleton roles --- only one instance per site: Rhua, Nfs, Dns, Proxy, Test
 - mutually exclusive roles --- can't be applied to the same node: Rhua, Cds, HAProxy, Proxy (all listen on port 443)
 - site-wide mutually exclusive roles --- chose either Nfs or Gluster
-- optional roles --- may be absent in one's site: Dns, HAProxy, Proxy, Cli, Test
+- optional roles --- may be absent in one's site: Dns, HAProxy, Proxy, Cli, Atomic Cli, Test
 - multi-roles --- usually multiple instances per site: CDS, Gluster, HAProxy, Cli
 
 Important Note: GlusterFS Configuration

--- a/deploy/atomic_cli.yml
+++ b/deploy/atomic_cli.yml
@@ -1,0 +1,6 @@
+---
+# file: atomic_cli.yml
+# client playbook
+- hosts: ATOMIC_CLI
+  roles:
+  - atomic_cli

--- a/deploy/roles/atomic_cli/tasks/main.yml
+++ b/deploy/roles/atomic_cli/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# file: roles/atomic_cli/tasks/main.yml
+# main atomic cli role tasks
+- name: set hostname
+  command: hostname "atomiccli.example.com"
+  with_indexed_items: "{{ groups['ATOMIC_CLI'] }}"
+  when: "'ATOMIC_CLI' in groups"
+  tags: atomic_cli

--- a/deploy/roles/common/tasks/ntp.yml
+++ b/deploy/roles/common/tasks/ntp.yml
@@ -5,15 +5,18 @@
 - name: install ntp
   package: "pkg={{ item }} state=installed"
   with_items: [ntp, ntpdate]
+  when: ansible_env.SUDO_USER != "cloud-user"
   tags: ntp
 
 - name: configure ntp
   template: src=ntp.conf.j2 dest=/etc/ntp.conf
   notify:
   - restart ntpd
+  when: ansible_env.SUDO_USER != "cloud-user"
   tags: ntp
 
 - name: enable and run ntpd
   service: name=ntpd state=started enabled=yes
+  when: ansible_env.SUDO_USER != "cloud-user"
   tags: ntp
 

--- a/deploy/roles/common/templates/hosts.j2
+++ b/deploy/roles/common/templates/hosts.j2
@@ -51,3 +51,7 @@
 {{ hostvars[cli]['ansible_eth0']['ipv4']['address'] }} cli0{{ loop.index }} cli0{{ loop.index }}.example.com
 {% endfor %}
 {% endif %}
+
+{% if 'ATOMIC_CLI' in groups %}
+{{ hostvars[groups['ATOMIC_CLI'][0]]['ansible_eth0']['ipv4']['address'] }} atomiccli atomiccli.example.com
+{% endif %}

--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -82,7 +82,7 @@
                   user='root'
                   state=present
   delegate_to: "{{ item }}"
-  with_items: "{{ groups['CDS']|default([]) + groups['HAPROXY']|default([]) + groups['RHUA']|default([]) + groups['DNS']|default([]) + groups['NFS']|default([]) + groups['GLUSTER']|default([]) + groups['CLI']|default([]) }}"
+  with_items: "{{ groups['CDS']|default([]) + groups['HAPROXY']|default([]) + groups['RHUA']|default([]) + groups['DNS']|default([]) + groups['NFS']|default([]) + groups['GLUSTER']|default([]) + groups['CLI']|default([]) + groups['ATOMIC_CLI']|default([]) }}"
   when: slurp_id_rsa_test|success
   tags: tests
   
@@ -100,11 +100,6 @@
   with_items: "{{ groups['RHUA']|default([]) }}"
   when: (extra_files is defined) and (upload_extra_files|success)
   tags: tests
-
-#TODO
-#- name: copy answers.yaml file
-#  src=/etc/rhui-installer/answers.yaml dest=/tmp/rhui3-tests/tests/rhui3_tests/
-#  tags: tests
 
 - name: run tests suite
   shell: nosetests -vs /tmp/rhui3-tests/tests &>>/tmp/rhui3test.log

--- a/deploy/site.yml
+++ b/deploy/site.yml
@@ -12,4 +12,5 @@
 - include: haproxy.yml
 - include: cds.yml
 - include: cli.yml
+- include: atomic_cli.yml
 - include: tests.yml

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,6 +10,7 @@ RHUI deployment with the following hosts:
 * two CDS instances
 * one HAProxy instance
 * one client instance
+* one atomic client instance
 * one test instance
 
 See the [RHUI deployment readme file ](https://github.com/RedHatQE/rhui3-automation/blob/master/deploy/README.md) for details. Also, if you use Gluster instead of NFS, note that you need two more hosts serving as Gluster instances.
@@ -17,15 +18,16 @@ See the [RHUI deployment readme file ](https://github.com/RedHatQE/rhui3-automat
 In addition, you need a ZIP file with the following files in the root of the archive:
 
 * `rhcert.pem` — This must be a valid Red Hat content certificate allowing access to the following products:
-  * _Red Hat Update Infrastructure 2.0 (RPMs)_
-  * _RHEL RHUI Atomic 7 Ostree Repo_
-  * _RHEL RHUI Server 7 Rhgs-server-nfs 3.1 OS_
+  * _Red Hat Update Infrastructure 2 (RPMs)_
+  * _Red Hat Enterprise Linux for SAP (RHEL 7 Server) (RPMs) from RHUI_
+* `rhcert_atomic.pem` — This must be a valid Red Hat content certificate allowing access to the following product:
+  * _Red Hat Enterprise Linux Atomic Host (Trees) from RHUI_
 * `rhui-rpm-upload-test-1-1.noarch.rpm` — This package will be uploaded to a custom repository.
 * `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository.
 
 Usage
 --------
-You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instance in the `[CLI]` section of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the required ZIP file as a parameter of the `--extra-vars` option.
+You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instances in the `[CLI]` and `[ATOMIC_CLI]` sections of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the required ZIP file as a parameter of the `--extra-vars` option.
 
 To install and run the test suite as part of the initial deployment or after a completed deployment, use the following command:
 

--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -1,0 +1,123 @@
+import nose, stitches, logging, yaml
+
+from rhui3_tests_lib.rhuimanager_cli import *
+from rhui3_tests_lib.rhuimanager_entitlement import *
+from rhui3_tests_lib.rhuimanager_repo import *
+from rhui3_tests_lib.rhuimanager_sync import *
+from rhui3_tests_lib.rhuimanager_instance import *
+from rhui3_tests_lib.instance import *
+from rhui3_tests_lib.util import Util
+
+from os.path import basename
+
+logging.basicConfig(level=logging.DEBUG)
+
+connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+atomic_cli=stitches.connection.Connection("atomiccli.example.com", "root", "/root/.ssh/id_rsa_test")
+
+with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
+    doc = yaml.load(file)
+
+atomic_repo_name = doc['atomic_repo']['name']
+
+class TestClient:
+
+    @classmethod
+    def setUpClass(cls):
+        cls.rhua_os_version = Util.get_rhua_version(connection)
+        print "*** Running %s: *** " % basename(__file__)
+        if cls.rhua_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL6\n*** Finished running %s. *** ' % basename(__file__))
+
+    def test_01_repo_setup(self):
+        '''do initial rhui-manager run'''
+        RHUIManager.initial_run(connection)
+
+    def test_02_add_cds(self):
+        '''
+            add a CDS
+        '''
+        cds_list = RHUIManagerInstance.list(connection, "cds")
+        nose.tools.assert_equal(cds_list, [])
+        RHUIManagerInstance.add_instance(connection, "cds", "cds01.example.com")
+
+    def test_03_add_hap(self):
+        '''
+            add an HAProxy Load-balancer
+        '''
+        hap_list = RHUIManagerInstance.list(connection, "loadbalancers")
+        nose.tools.assert_equal(hap_list, [])
+        RHUIManagerInstance.add_instance(connection, "loadbalancers", "hap01.example.com")
+
+    def test_04_upload_atomic_cert(self):
+        '''
+            upload atomic cert
+        '''
+        RHUIManagerEntitlements.upload_rh_certificate(connection, "/tmp/extra_rhui_files/rhcert_atomic.pem")
+
+    def test_05_add_atomic_repo(self):
+        '''
+           add the RHEL RHUI Atomic 7 Ostree Repo
+        '''
+        RHUIManagerRepo.add_rh_repo_by_product(connection, [atomic_repo_name])
+
+    #def test_06_sync_atomic_repo(self):
+    #    '''
+    #       sync the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only)
+    #    '''
+    #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, atomic_repo_name)
+    #    RHUIManagerSync.sync_repo(connection, [atomic_repo_name + atomic_repo_version])
+
+    def test_07_generate_atomic_ent_cert(self):
+        '''
+           generate an entitlement certificate for the Atomic repo (RHEL 7+ only)
+        '''
+        RHUIManagerClient.generate_ent_cert(connection, [atomic_repo_name], "test_atomic_ent_cli", "/root/")
+        Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
+        Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
+
+    def test_08_create_atomic_pkg(self):
+        '''
+           create an Atomic client configuration package (RHEL 7+ only)
+        '''
+        RHUIManager.initial_run(connection)
+        RHUIManagerClient.create_atomic_conf_pkg(connection, "/root", "test_atomic_pkg", "/root/test_atomic_ent_cli.crt", "/root/test_atomic_ent_cli.key")
+        Expect.ping_pong(connection, "test -f /root/test_atomic_pkg.tar.gz && echo SUCCESS", "[^ ]SUCCESS")
+
+    #def test_09_check_sync_status_of_atomic_repo(self):
+    #    '''
+    #       check if Atomic repo was synced to pull the content (RHEL 7+ only)
+    #    '''
+    #    RHUIManager.initial_run(connection)
+    #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, atomic_repo_name)
+    #    RHUIManagerSync.wait_till_repo_synced(connection, atomic_repo_name + atomic_repo_version)
+
+    def test_10_install_atomic_pkg(self):
+        '''
+           install atomic pkg on atomic host
+        '''
+        Util.install_pkg_from_rhua(connection, atomic_cli, "/root/test_atomic_pkg.tar.gz")
+
+    #def test_11_pull_atomic_content(self):
+    #    '''
+    #       pull atomic content
+    #    '''
+    #    Expect.ping_pong(atomic_cli, "sudo ostree pull rhui-rhel-rhui-atomic-7-ostree-repo:rhel-atomic-host/7/x86_64/standard && echo SUCCESS", "[^ ]SUCCESS")
+
+    def test_99_cleanup(self):
+        '''
+           remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+), remove rpms from cli, uninstall cds, hap
+        '''
+        RHUIManager.initial_run(connection)
+        RHUIManagerRepo.delete_all_repos(connection)
+        nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+        RHUIManagerInstance.delete(connection, "loadbalancers", ["hap01.example.com"])
+        RHUIManagerInstance.delete(connection, "cds", ["cds01.example.com"])
+        Expect.ping_pong(connection, "rm -f /root/test_atomic_ent_cli* && echo SUCCESS", "[^ ]SUCCESS")
+        Expect.ping_pong(connection, "rm -f /root/test_atomic_pkg.tar.gz && echo SUCCESS", "[^ ]SUCCESS")
+     #   Expect.ping_pong(atomic_cli, "sudo ostree remote delete rhui-rhel-rhui-atomic-7-ostree-repo \
+     #                                    && echo SUCCESS", "[^ ]SUCCESS")
+
+    @classmethod
+    def tearDownClass(cls):
+        print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -1,4 +1,4 @@
-import nose, unittest, stitches, logging, yaml, time, re
+import nose, stitches, logging, yaml
 
 from rhui3_tests_lib.rhuimanager_cli import *
 from rhui3_tests_lib.rhuimanager_entitlement import *
@@ -9,10 +9,6 @@ from rhui3_tests_lib.instance import *
 from rhui3_tests_lib.util import Util
 
 from os.path import basename
-
-# The parts related to Atomic are applicable to RHEL 7+ only.
-import platform
-atomic_unsupported = float(platform.linux_distribution()[1]) < 7
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -32,214 +28,153 @@ atomic_repo_name = doc['atomic_repo']['name']
 def setUp():
     print "*** Running %s: *** " % basename(__file__)
 
-def test_01_repo_setup():
-    '''do initial rhui-manager run'''
-    RHUIManager.initial_run(connection)
+class TestClient:
 
-def test_02_upload_rh_certificate():
-    '''
-       upload a new or updated Red Hat content certificate
-    '''
-    list = RHUIManagerEntitlements.upload_rh_certificate(connection)
-    nose.tools.assert_not_equal(len(list), 0)
+    @classmethod
+    def setUpClass(cls):
+        cls.rhua_os_version = Util.get_rhua_version(connection)
+        print "*** Running %s: *** " % basename(__file__)
 
-def test_03_add_cds():
-    '''
-        add a CDS
-    '''
-    cds_list = RHUIManagerInstance.list(connection, "cds")
-    nose.tools.assert_equal(cds_list, [])
-    RHUIManagerInstance.add_instance(connection, "cds", "cds01.example.com")
+    def test_01_repo_setup(self):
+        '''do initial rhui-manager run'''
+        RHUIManager.initial_run(connection)
 
-def test_04_add_hap():
-    '''
-        add an HAProxy Load-balancer
-    '''
-    hap_list = RHUIManagerInstance.list(connection, "loadbalancers")
-    nose.tools.assert_equal(hap_list, [])
-    RHUIManagerInstance.add_instance(connection, "loadbalancers", "hap01.example.com")
+    def test_02_upload_rh_certificate(self):
+        '''
+           upload a new or updated Red Hat content certificate
+        '''
+        list = RHUIManagerEntitlements.upload_rh_certificate(connection)
+        nose.tools.assert_not_equal(len(list), 0)
 
-def test_05_add_repos_upload_rpm_sync():
-    '''
-       add a custom and RH content repos to protect by a cli entitlement cert, upload rpm, sync
-    '''
-    RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
-    RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
-    RHUIManagerRepo.add_rh_repo_by_repo(connection, [yum_repo1_name + yum_repo1_version + " \(Yum\)", yum_repo2_name + yum_repo2_version + " \(Yum\)"])
-    RHUIManagerSync.sync_repo(connection, [yum_repo1_name + yum_repo1_version, yum_repo2_name + yum_repo2_version])
+    def test_03_add_cds(self):
+        '''
+            add a CDS
+        '''
+        cds_list = RHUIManagerInstance.list(connection, "cds")
+        nose.tools.assert_equal(cds_list, [])
+        RHUIManagerInstance.add_instance(connection, "cds", "cds01.example.com")
 
-def test_06_generate_ent_cert():
-    '''
-       generate an entitlement certificate
-    '''
-    if atomic_unsupported:
-       RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", yum_repo1_name], "test_ent_cli", "/root/")
-    else:
-       RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", yum_repo2_name], "test_ent_cli", "/root/")
-    Expect.ping_pong(connection, "test -f /root/test_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
-    Expect.ping_pong(connection, "test -f /root/test_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
+    def test_04_add_hap(self):
+        '''
+            add an HAProxy Load-balancer
+        '''
+        hap_list = RHUIManagerInstance.list(connection, "loadbalancers")
+        nose.tools.assert_equal(hap_list, [])
+        RHUIManagerInstance.add_instance(connection, "loadbalancers", "hap01.example.com")
 
-def test_07_create_cli_rpm():
-    '''
-       create a client configuration RPM from an entitlement certificate
-    '''
-    RHUIManager.initial_run(connection)
-    RHUIManagerClient.create_conf_rpm(connection, "/root", "/root/test_ent_cli.crt", "/root/test_ent_cli.key", "test_cli_rpm", "3.0")
-    Expect.ping_pong(connection, "test -f /root/test_cli_rpm-3.0/build/RPMS/noarch/test_cli_rpm-3.0-1.noarch.rpm && echo SUCCESS", "[^ ]SUCCESS")
+    def test_05_add_repos_upload_rpm_sync(self):
+        '''
+           add a custom and RH content repos to protect by a cli entitlement cert, upload rpm, sync
+        '''
+        RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
+        RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
+        RHUIManagerRepo.add_rh_repo_by_repo(connection, [yum_repo1_name + yum_repo1_version + " \(Yum\)", yum_repo2_name + yum_repo2_version + " \(Yum\)"])
+        RHUIManagerSync.sync_repo(connection, [yum_repo1_name + yum_repo1_version, yum_repo2_name + yum_repo2_version])
 
-def test_08_remove_amazon_rhui_conf_rpm():
-    '''
-       remove amazon rhui configuration rpm from client
-    '''
-    Util.remove_amazon_rhui_conf_rpm(cli)
+    def test_06_generate_ent_cert(self):
+        '''
+           generate an entitlement certificate
+        '''
+        if self.rhua_os_version < 7:
+           RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", yum_repo1_name], "test_ent_cli", "/root/")
+        else:
+           RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", yum_repo2_name], "test_ent_cli", "/root/")
+        Expect.ping_pong(connection, "test -f /root/test_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
+        Expect.ping_pong(connection, "test -f /root/test_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
 
-def test_09_install_conf_rpm():
-    '''
-       install configuration rpm to client
-    '''
-    Util.install_pkg_from_rhua(connection, cli, "/root/test_cli_rpm-3.0/build/RPMS/noarch/test_cli_rpm-3.0-1.noarch.rpm")
+    def test_07_create_cli_rpm(self):
+        '''
+           create a client configuration RPM from an entitlement certificate
+        '''
+        RHUIManager.initial_run(connection)
+        RHUIManagerClient.create_conf_rpm(connection, "/root", "/root/test_ent_cli.crt", "/root/test_ent_cli.key", "test_cli_rpm", "3.0")
+        Expect.ping_pong(connection, "test -f /root/test_cli_rpm-3.0/build/RPMS/noarch/test_cli_rpm-3.0-1.noarch.rpm && echo SUCCESS", "[^ ]SUCCESS")
 
-def test_10_check_cli_conf_rpm_version():
-    '''
-       check client configuration rpm version
-    '''
-    Expect.ping_pong(cli, "[ `rpm -q --queryformat \"%{VERSION}\" test_cli_rpm` = '3.0' ] && echo SUCCESS", "[^ ]SUCCESS")
+    def test_08_remove_amazon_rhui_conf_rpm(self):
+        '''
+           remove amazon rhui configuration rpm from client
+        '''
+        Util.remove_amazon_rhui_conf_rpm(cli)
 
-def test_11_check_repo_sync_status():
-    '''
-       check if RH repos were synced to install rpm
-    '''
-    RHUIManager.initial_run(connection)
-    if atomic_unsupported:
-        RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo1_name + yum_repo1_version])
-    else:
-        RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo2_name + yum_repo2_version])
+    def test_09_install_conf_rpm(self):
+        '''
+           install configuration rpm to client
+        '''
+        Util.install_pkg_from_rhua(connection, cli, "/root/test_cli_rpm-3.0/build/RPMS/noarch/test_cli_rpm-3.0-1.noarch.rpm")
 
-def test_12_install_rpm_from_custom_repo():
-    '''
-       install rpm from a custom repo
-    '''
-    Expect.ping_pong(cli, "yum install -y rhui-rpm-upload-test --nogpgcheck && echo SUCCESS", "[^ ]SUCCESS", 60)
+    def test_10_check_cli_conf_rpm_version(self):
+        '''
+           check client configuration rpm version
+        '''
+        Expect.ping_pong(cli, "[ `rpm -q --queryformat \"%{VERSION}\" test_cli_rpm` = '3.0' ] && echo SUCCESS", "[^ ]SUCCESS")
 
-def test_13_install_rpm_from_rh_repo():
-    '''
-       install rpm from a RH repo
-    '''
-    if atomic_unsupported:
-       Expect.ping_pong(cli, "yum install -y js && echo SUCCESS", "[^ ]SUCCESS", 60)
-    else:
-       Expect.ping_pong(cli, "yum install -y vm-dump-metrics && echo SUCCESS", "[^ ]SUCCESS", 60)
+    def test_11_check_repo_sync_status(self):
+        '''
+           check if RH repos were synced to install rpm
+        '''
+        RHUIManager.initial_run(connection)
+        if self.rhua_os_version < 7:
+            RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo1_name + yum_repo1_version])
+        else:
+            RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo2_name + yum_repo2_version])
 
-def test_14_create_docker_cli_rpm():
-    '''
-       create a docker client configuration RPM
-    '''
-    RHUIManager.initial_run(connection)
-    RHUIManagerClient.create_docker_conf_rpm(connection, "/root", "test_docker_cli_rpm", "4.0")
-    Expect.ping_pong(connection, "test -f /root/test_docker_cli_rpm-4.0/build/RPMS/noarch/test_docker_cli_rpm-4.0-1.noarch.rpm && echo SUCCESS", "[^ ]SUCCESS")
+    def test_12_install_rpm_from_custom_repo(self):
+        '''
+           install rpm from a custom repo
+        '''
+        Expect.ping_pong(cli, "yum install -y rhui-rpm-upload-test --nogpgcheck && echo SUCCESS", "[^ ]SUCCESS", 60)
 
-def test_15_install_docker_rpm():
-    '''
-       install a docker client configuration RPM to client (RHEL 7+ CLI only)
-    '''
-    if atomic_unsupported:
-        return    
-    Util.install_pkg_from_rhua(connection, cli, "/root/test_docker_cli_rpm-4.0/build/RPMS/noarch/test_docker_cli_rpm-4.0-1.noarch.rpm")
+    def test_13_install_rpm_from_rh_repo(self):
+        '''
+           install rpm from a RH repo
+        '''
+        if self.rhua_os_version < 7:
+           Expect.ping_pong(cli, "yum install -y js && echo SUCCESS", "[^ ]SUCCESS", 60)
+        else:
+           Expect.ping_pong(cli, "yum install -y vm-dump-metrics && echo SUCCESS", "[^ ]SUCCESS", 60)
 
-def test_16_check_docker_rpm_version():
-    '''
-       check docker rpm version (RHEL 7+ CLI only)
-    '''
-    if atomic_unsupported:
-        return  
-    Expect.ping_pong(cli, "[ `rpm -q --queryformat \"%{VERSION}\" test_docker_cli_rpm` = '4.0' ] && echo SUCCESS", "[^ ]SUCCESS")
+    def test_14_create_docker_cli_rpm(self):
+        '''
+           create a docker client configuration RPM
+        '''
+        RHUIManager.initial_run(connection)
+        RHUIManagerClient.create_docker_conf_rpm(connection, "/root", "test_docker_cli_rpm", "4.0")
+        Expect.ping_pong(connection, "test -f /root/test_docker_cli_rpm-4.0/build/RPMS/noarch/test_docker_cli_rpm-4.0-1.noarch.rpm && echo SUCCESS", "[^ ]SUCCESS")
 
-def test_17_add_atomic_repo():
-    '''
-       add the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only)
-    '''
-    if atomic_unsupported:
-        return
-    RHUIManager.initial_run(connection)
-    RHUIManagerEntitlements.upload_rh_certificate(connection, "/tmp/extra_rhui_files/rhcert_atomic.pem")
-    RHUIManagerRepo.add_rh_repo_by_product(connection, [atomic_repo_name])
+    def test_15_install_docker_rpm(self):
+        '''
+           install a docker client configuration RPM to client
+        '''
+        if self.rhua_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL6')
+        Util.install_pkg_from_rhua(connection, cli, "/root/test_docker_cli_rpm-4.0/build/RPMS/noarch/test_docker_cli_rpm-4.0-1.noarch.rpm")
 
-def test_18_sync_atomic_repo():
-    '''
-       sync the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only)
-    '''
-    if atomic_unsupported:
-        return
-    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, atomic_repo_name)
-    RHUIManagerSync.sync_repo(connection, [atomic_repo_name + atomic_repo_version])
+    def test_16_check_docker_rpm_version(self):
+        '''
+           check docker rpm version
+        '''
+        if self.rhua_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL6')
+        Expect.ping_pong(cli, "[ `rpm -q --queryformat \"%{VERSION}\" test_docker_cli_rpm` = '4.0' ] && echo SUCCESS", "[^ ]SUCCESS")
 
-def test_19_generate_atomic_ent_cert():
-    '''
-       generate an entitlement certificate for the Atomic repo (RHEL 7+ only)
-    '''
-    if atomic_unsupported:
-        return
-    RHUIManagerClient.generate_ent_cert(connection, [atomic_repo_name], "test_atomic_ent_cli", "/root/")
-    Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
-    Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
+    def test_99_cleanup(self):
+        '''
+           remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+), remove rpms from cli, uninstall cds, hap
+        '''
+        RHUIManager.initial_run(connection)
+        RHUIManagerRepo.delete_all_repos(connection)
+        nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+        RHUIManagerInstance.delete(connection, "loadbalancers", ["hap01.example.com"])
+        RHUIManagerInstance.delete(connection, "cds", ["cds01.example.com"])
+        Expect.ping_pong(connection, "rm -f /root/test_ent_cli* && echo SUCCESS", "[^ ]SUCCESS")
+        Expect.ping_pong(connection, "rm -rf /root/test_cli_rpm-3.0/ && echo SUCCESS", "[^ ]SUCCESS")
+        Expect.ping_pong(connection, "rm -rf /root/test_docker_cli_rpm-4.0/ && echo SUCCESS", "[^ ]SUCCESS")
+        if self.rhua_os_version >=7:
+            Util.remove_rpm(cli, ["vm-dump-metrics", "test_docker_cli_rpm"])
+        else:
+            Util.remove_rpm(cli, ["js"])
+        Util.remove_rpm(cli, ["test_cli_rpm", "rhui-rpm-upload-test"])
 
-def test_20_create_atomic_pkg():
-    '''
-       create an Atomic client configuration package (RHEL 7+ only)
-    '''
-    if atomic_unsupported:
-        return
-    RHUIManager.initial_run(connection)
-    RHUIManagerClient.create_atomic_conf_pkg(connection, "/root", "test_atomic_pkg", "/root/test_atomic_ent_cli.crt", "/root/test_atomic_ent_cli.key")
-    Expect.ping_pong(connection, "test -f /root/test_atomic_pkg.tar.gz && echo SUCCESS", "[^ ]SUCCESS")
-
-def test_21_check_sync_status_of_atomic_repo():
-    '''
-       check if Atomic repo was synced to pull the content (RHEL 7+ only)
-    '''
-    if atomic_unsupported:
-        return
-    RHUIManager.initial_run(connection)
-    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, atomic_repo_name)
-    RHUIManagerSync.wait_till_repo_synced(connection, atomic_repo_name + atomic_repo_version)
-
-def test_22_install_atomic_pkg():
-    '''
-       install atomic pkg on atomic host
-    '''
-    if atomic_unsupported:
-        return
-    Util.install_pkg_from_rhua(connection, atomic_cli, "/root/test_atomic_pkg.tar.gz")
-
-def test_23_pull_atomic_content():
-    '''
-       pull atomic content
-    '''
-    if atomic_unsupported:
-        return
-    Expect.ping_pong(atomic_cli, "sudo ostree pull rhui-rhel-rhui-atomic-7-ostree-repo:rhel-atomic-host/7/x86_64/standard && echo SUCCESS", "[^ ]SUCCESS")
-
-def test_99_cleanup():
-    '''
-       remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+), remove rpms from cli, uninstall cds, hap
-    '''
-    RHUIManager.initial_run(connection)
-    RHUIManagerRepo.delete_all_repos(connection)
-    nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
-    RHUIManagerInstance.delete(connection, "loadbalancers", ["hap01.example.com"])
-    RHUIManagerInstance.delete(connection, "cds", ["cds01.example.com"])
-    Expect.ping_pong(connection, "rm -f /root/test_ent_cli* && echo SUCCESS", "[^ ]SUCCESS")
-    Expect.ping_pong(connection, "rm -rf /root/test_cli_rpm-3.0/ && echo SUCCESS", "[^ ]SUCCESS")
-    Expect.ping_pong(connection, "rm -rf /root/test_docker_cli_rpm-4.0/ && echo SUCCESS", "[^ ]SUCCESS")
-    if not atomic_unsupported:
-        Expect.ping_pong(connection, "rm -f /root/test_atomic_ent_cli* && echo SUCCESS", "[^ ]SUCCESS")
-        Expect.ping_pong(connection, "rm -f /root/test_atomic_pkg.tar.gz && echo SUCCESS", "[^ ]SUCCESS")
-        Util.remove_rpm(cli, ["vm-dump-metrics", "test_docker_cli_rpm"])
-        Expect.ping_pong(atomic_cli, "sudo ostree remote delete rhui-rhel-rhui-atomic-7-ostree-repo \
-                                     && echo SUCCESS", "[^ ]SUCCESS")
-    else:
-        Util.remove_rpm(cli, ["js"])
-    Util.remove_rpm(cli, ["test_cli_rpm", "rhui-rpm-upload-test"])
-
-def tearDown():
-    print "*** Finished running %s. *** " % basename(__file__)
+    @classmethod
+    def tearDownClass(cls):
+        print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -11,6 +11,12 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
+with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
+    doc = yaml.load(file)
+
+yum_repo_name = doc['yum_repo1']['name']
+yum_repo_version = doc['yum_repo1']['version']
+
 def setUp():
     print "*** Running %s: *** " % basename(__file__)
 
@@ -58,18 +64,18 @@ def test_07_remove_3_custom_repos():
 
 def test_08_add_rh_repo_by_repository():
     '''Add a RH repo by repository'''
-    RHUIManagerRepo.add_rh_repo_by_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\) \(Yum\)"])
+    RHUIManagerRepo.add_rh_repo_by_repo(connection, [yum_repo_name + yum_repo_version + " \(Yum\)"])
     nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
 def test_09_delete_one_repo():
     '''Remove a RH repo'''
-    RHUIManagerRepo.delete_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\).*"])
+    RHUIManagerRepo.delete_repo(connection, [yum_repo_name + ".*"])
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def test_10_add_rh_repo_by_product():
     '''Add a RH repo by product'''
-    RHUIManagerRepo.add_rh_repo_by_product(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\)"])
-    nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
+    RHUIManagerRepo.add_rh_repo_by_product(connection, [yum_repo_name])
+    #nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
 def test_11_delete_repo():
     '''Remove a RH repo'''

--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -49,7 +49,7 @@ def test_06_upload_rpm_to_custom_repo():
 def test_06_01_upload_several_rpms_to_custom_repo():
     '''Upload several rpms to the custom repo from a directory'''
     RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/")
- 
+
 def test_06_02_check_for_package():
     '''Check the packages list'''
     nose.tools.assert_equal(RHUIManagerRepo.check_for_package(connection, "custom-i386-x86_64", ""), ["rhui-rpm-upload-test-1-1.noarch.rpm", "rhui-rpm-upload-trial-1-1.noarch.rpm"])

--- a/tests/rhui3_tests/test_sync_managment.py
+++ b/tests/rhui3_tests/test_sync_managment.py
@@ -11,6 +11,12 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
+with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
+    doc = yaml.load(file)
+
+yum_repo_name = doc['yum_repo1']['name']
+yum_repo_version = doc['yum_repo1']['version']
+
 def setUp():
     print "*** Running %s: *** " % basename(__file__)
 
@@ -18,22 +24,22 @@ def test_01_setup():
     '''do rhui-manager login, upload RH cert, add a repo to sync '''
     RHUIManager.initial_run(connection)
     RHUIManagerEntitlements.upload_rh_certificate(connection)
-    RHUIManagerRepo.add_rh_repo_by_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\) \(Yum\)"])
+    RHUIManagerRepo.add_rh_repo_by_repo(connection, [yum_repo_name + yum_repo_version + " \(Yum\)"])
 
 def test_02_sync_repo():
     '''sync a RH repo '''
-    RHUIManagerSync.sync_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\)"])
+    RHUIManagerSync.sync_repo(connection, [yum_repo_name + yum_repo_version])
 
 def test_03_check_sync_status():
     '''check sync status of the repo'''
-    Expect.ping_pong(connection, "rhui-manager status | grep \"Red Hat Update Infrastructure 2.0 (RPMs) (6Server-x86_64)\" | grep \"SUCCESS\|SYNCING\" && echo SUCCESS", "[^ ]SUCCESS", 120)
+    Expect.ping_pong(connection, "rhui-manager status | grep yum_repo_name + yum_repo_version | grep \"Success\|Running\" && echo SUCCESS", "[^ ]SUCCESS", 120)
 
 def test_04_cleanup():
     '''Wait until repo is synced and remove it then'''
-    RHUIManagerSync.wait_till_repo_synced(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\) \(6Server-x86_64\)"])
+    RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo_name + yum_repo_version])
 
     '''remove the RH repo '''
-    RHUIManagerRepo.delete_repo(connection, ["Red Hat Update Infrastructure 2.0 \(RPMs\).*"])
+    RHUIManagerRepo.delete_repo(connection, [yum_repo_name + ".*"])
 
 def tearDown():
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_sync_managment.py
+++ b/tests/rhui3_tests/test_sync_managment.py
@@ -30,14 +30,15 @@ def test_02_sync_repo():
     '''sync a RH repo '''
     RHUIManagerSync.sync_repo(connection, [yum_repo_name + yum_repo_version])
 
-def test_03_check_sync_status():
-    '''check sync status of the repo'''
-    Expect.ping_pong(connection, "rhui-manager status | grep yum_repo_name + yum_repo_version | grep \"Success\|Running\" && echo SUCCESS", "[^ ]SUCCESS", 120)
+def test_03_check_sync_started():
+    '''ensure that sync started'''
+    RHUIManagerSync.check_sync_started(connection, [yum_repo_name + yum_repo_version])
 
-def test_04_cleanup():
-    '''Wait until repo is synced and remove it then'''
+def test_04_wait_till_repo_synced():
+    '''wait until repo is synced'''
     RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo_name + yum_repo_version])
 
+def test_99_cleanup():
     '''remove the RH repo '''
     RHUIManagerRepo.delete_repo(connection, [yum_repo_name + ".*"])
 

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -1,0 +1,8 @@
+yum_repo1:
+    name: "Red Hat Update Infrastructure 2 \\(RPMs\\)"
+    version: " \\(6Server-x86_64\\)"
+yum_repo2:
+    name: "Red Hat Enterprise Linux for SAP \\(RHEL 7 Server\\) \\(RPMs\\) from RHUI"
+    version: " \\(7Server-x86_64\\)"
+atomic_repo:
+    name: "Red Hat Enterprise Linux Atomic Host \\(Trees\\) from RHUI"

--- a/tests/rhui3_tests_lib/rhuimanager_entitlement.py
+++ b/tests/rhui3_tests_lib/rhuimanager_entitlement.py
@@ -66,12 +66,10 @@ class RHUIManagerEntitlements(object):
         return sorted(repo_list)
 
     @staticmethod
-    def upload_rh_certificate(connection):
+    def upload_rh_certificate(connection, certificate_file = '/tmp/extra_rhui_files/rhcert.pem'):
         '''
         upload a new or updated Red Hat content certificate
         '''
-        
-        certificate_file = '/tmp/extra_rhui_files/rhcert.pem'
         
         if connection.recv_exit_status("ls -la %s" % certificate_file)!=0:
             raise ExpectFailed("Missing certificate file: %s" % certificate_file)

--- a/tests/rhui3_tests_lib/rhuimanager_entitlement.py
+++ b/tests/rhui3_tests_lib/rhuimanager_entitlement.py
@@ -16,7 +16,7 @@ class RHUIManagerEntitlements(object):
     Represents -= Entitlements Manager =- RHUI screen
     '''
     prompt = 'rhui \(entitlements\) => '
- 
+
     @staticmethod
     def list(connection):
         '''
@@ -26,19 +26,19 @@ class RHUIManagerEntitlements(object):
         lines = RHUIManager.list_lines(connection, prompt=RHUIManagerEntitlements.prompt)
         Expect.enter(connection, 'q')
         return lines
-    
+
     @staticmethod
     def list_rh_entitlements(connection):
         '''
         list Red Hat entitlements
         '''
-        
+
         RHUIManager.screen(connection, "entitlements")
         Expect.enter(connection, "l")
         match = Expect.match(connection, re.compile("(.*)" + RHUIManagerEntitlements.prompt, re.DOTALL))
-        
+
         matched_string = match[0].replace('l\r\n\r\nRed Hat Entitlements\r\n\r\n  \x1b[92mValid\x1b[0m\r\n    ', '', 1)
-        
+
         entitlements_list = []
         pattern = re.compile('(.*?\r\n.*?pem)', re.DOTALL)
         for entitlement in pattern.findall(matched_string):
@@ -52,13 +52,13 @@ class RHUIManagerEntitlements(object):
         '''
         list custom entitlements
         '''
-         
+
         RHUIManager.screen(connection, "entitlements")
         Expect.enter(connection, "c")
         match = Expect.match(connection, re.compile("c\r\n\r\nCustom Repository Entitlements\r\n\r\n(.*)" + RHUIManagerEntitlements.prompt, re.DOTALL))[0]
-        
+
         repo_list = []
-        
+
         for line in match.splitlines():
             if "Name:" in line:
                 repo_list.append(line.replace("Name:", "").strip())
@@ -70,7 +70,7 @@ class RHUIManagerEntitlements(object):
         '''
         upload a new or updated Red Hat content certificate
         '''
-        
+
         if connection.recv_exit_status("ls -la %s" % certificate_file)!=0:
             raise ExpectFailed("Missing certificate file: %s" % certificate_file)
 

--- a/tests/rhui3_tests_lib/rhuimanager_instance.py
+++ b/tests/rhui3_tests_lib/rhuimanager_instance.py
@@ -35,7 +35,7 @@ class RHUIManagerInstance(object):
         @param hostname instance
         @param update: Bool; update the cds or hap if it is already tracked or raise ExpectFailed
         '''
-        
+
         RHUIManager.screen(connection, screen)
         Expect.enter(connection, "a")
         Expect.expect(connection, ".*Hostname of the .*instance to register:")

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -164,6 +164,23 @@ class RHUIManagerRepo(object):
         return repolist
 
     @staticmethod
+    def get_repo_version(connection, reponame):
+        '''
+        get repo version
+        '''
+        repolist = RHUIManagerRepo.list(connection)
+        # delete escape back slash from the reponame
+        reponame = reponame.replace("\\", "")
+        # get full repo name with its version from the list of all repos
+        full_reponame = next((s for s in repolist if reponame in s), None)
+        #return full_reponame
+        # get its version
+        repo_version = re.sub('^.*\((.*?)\)[^\(]*$', '\g<1>', full_reponame)
+
+        #return repo_version
+        return " \(" + repo_version + "\)"
+
+    @staticmethod
     def delete_repo(connection, repolist):
         '''
         delete a repository from the RHUI

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -186,7 +186,10 @@ class RHUIManagerRepo(object):
         Expect.expect(connection, "Enter value .*:")
         Expect.enter(connection, "c")
         RHUIManager.proceed_without_check(connection)
+        # Wait until all repos are deleted
         RHUIManager.quit(connection, "", 360)
+        while len(RHUIManagerRepo.list(connection)) != 0:
+            time.sleep(10)
 
     @staticmethod
     def upload_content(connection, repolist, path):

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -27,13 +27,13 @@ class RHUIManagerRepo(object):
             Expect.enter(connection, displayname)
             if displayname != "":
                 checklist.append("Name: " + displayname)
-            else:   
+            else:
                 checklist.append("Name: " + reponame)
             Expect.expect(connection, "Unique path at which the repository will be served.*:")
             Expect.enter(connection, path)
             if path != "":
                 path_real = path
-            else:   
+            else:
                 path_real = reponame
             checklist.append("Path: " + path_real)
             Expect.expect(connection, "Enter value.*:")
@@ -45,7 +45,7 @@ class RHUIManagerRepo(object):
                 Expect.enter(connection, entitlement_path)
                 if entitlement_path != "":
                     checklist.append("Entitlement: " + entitlement_path)
-                else:       
+                else:
                     educated_guess, replace_count = re.subn("(i386|x86_64)", "$basearch", path_real)
                     if replace_count > 1:
                         # bug 815975
@@ -59,7 +59,7 @@ class RHUIManagerRepo(object):
                 Expect.enter(connection, redhat_gpg)
                 if redhat_gpg == "y":
                     checklist.append("Red Hat GPG Key: Yes")
-                else:       
+                else:
                     checklist.append("Red Hat GPG Key: No")
                 Expect.expect(connection, "Will the repository be used to host any custom GPG signed content\? \(y/n\)")
                 if custom_gpg:
@@ -69,17 +69,17 @@ class RHUIManagerRepo(object):
                     Expect.expect(connection, "Would you like to enter another public key\? \(y/n\)")
                     Expect.enter(connection, "n")
                     checklist.append("Custom GPG Keys: '" + custom_gpg + "'")
-                else:       
+                else:
                     Expect.enter(connection, "n")
                     checklist.append("Custom GPG Keys: \(None\)")
-            else:           
+            else:
                 Expect.enter(connection, "n")
-                checklist.append("GPG Check No") 
+                checklist.append("GPG Check No")
                 checklist.append("Red Hat GPG Key: No")
-    
+
             RHUIManager.proceed_with_check(connection, "The following repository will be created:", checklist)
             RHUIManager.quit(connection, "Successfully created repository *")
-        else:      
+        else:
             Expect.enter(connection, '\x03')
             RHUIManager.quit(connection)
 
@@ -145,9 +145,9 @@ class RHUIManagerRepo(object):
 
     @staticmethod
     def list(connection):
-        ''' 
+        '''
         list repositories
-        '''     
+        '''
         RHUIManager.screen(connection, "repo")
         Expect.enter(connection, "l")
         # eating prompt!!

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -157,14 +157,7 @@ class RHUIManagerRepo(object):
         reslist = map(lambda x: x.strip(), ret.split("\r\n"))
         repolist = []
         for line in reslist:
-            # Readling lines and searching for repos
-            if line == '':
-                continue
-            if "Custom Repositories" in line:
-                continue
-            if "Red Hat Repositories" in line:
-                continue
-            if "No repositories are currently managed by the RHUI" in line:
+            if line in ["", "Custom Repositories", "Red Hat Repositories", "OSTree", "Docker", "Yum", "No repositories are currently managed by the RHUI"]:
                 continue
             repolist.append(line)
         Expect.enter(connection, 'q')

--- a/tests/rhui3_tests_lib/rhuimanager_sync.py
+++ b/tests/rhui3_tests_lib/rhuimanager_sync.py
@@ -43,6 +43,19 @@ class RHUIManagerSync(object):
         Expect.enter(connection, 'q') 
         return ret_list
 
+   @staticmethod
+    def check_sync_started(connection, repolist):
+        '''ensure that sync started'''
+        for repo in repolist:
+            reposync = ["", "", "Never"]
+            while reposync[2] in ["Never", "Unknown"]:
+                time.sleep(10)
+                reposync = RHUIManagerSync.get_repo_status(connection, repo)
+            if reposync[2] in ["Running", "Success"]:
+                pass
+            else:
+                raise TypeError("Something went wrong")
+
     @staticmethod
     def wait_till_repo_synced(connection, repolist):
         '''

--- a/tests/rhui3_tests_lib/rhuimanager_sync.py
+++ b/tests/rhui3_tests_lib/rhuimanager_sync.py
@@ -53,4 +53,6 @@ class RHUIManagerSync(object):
             while reposync[2] in ["Running", "Never", "Unknown"]:
                 time.sleep(10)
                 reposync = RHUIManagerSync.get_repo_status(connection, repo)
+            if reposync[2] == "Error":
+                raise TypeError("The repo sync returned Error")
             nose.tools.assert_equal(reposync[2], "Success")

--- a/tests/rhui3_tests_lib/rhuimanager_sync.py
+++ b/tests/rhui3_tests_lib/rhuimanager_sync.py
@@ -46,7 +46,7 @@ class RHUIManagerSync(object):
     @staticmethod
     def wait_till_repo_synced(connection, repolist):
         '''
-        wait untill repo is synced
+        wait until repo is synced
         '''
         for repo in repolist:
             reposync = ["", "", "Running"]

--- a/tests/rhui3_tests_lib/rhuimanager_sync.py
+++ b/tests/rhui3_tests_lib/rhuimanager_sync.py
@@ -40,10 +40,10 @@ class RHUIManagerSync(object):
             ret_list[i] = ret_list[i].strip()
 
         Expect.enter(connection, '\x03')
-        Expect.enter(connection, 'q') 
+        Expect.enter(connection, 'q')
         return ret_list
 
-   @staticmethod
+    @staticmethod
     def check_sync_started(connection, repolist):
         '''ensure that sync started'''
         for repo in repolist:

--- a/tests/rhui3_tests_lib/util.py
+++ b/tests/rhui3_tests_lib/util.py
@@ -125,60 +125,18 @@ class Util(object):
             return (None, None)
 
     @staticmethod
+    def get_rhua_version(connection):
+        '''
+        get RHUA os version
+        '''
+        stdin, stdout, stderr = connection.exec_command('grep -E -o "[0-9]" /etc/redhat-release | head -1')
+        for line in  stdout:
+            return int(line)
+
+    @staticmethod
     def wildcard(hostname):
         """ Hostname wildcard """
         hostname_particles = hostname.split('.')
         hostname_particles[0] = "*"
         return ".".join(hostname_particles)
 
-    @staticmethod
-    def generate_answers(rhuisetup, version="1.0", generate_certs=True, proxy_host=None, proxy_port="3128",
-                         proxy_user="rhua", proxy_password=None, capassword=None, answersfile_name="/etc/rhui/answers"):
-        ''' Generate answers file ant put it to RHUA node'''
-        answersfile = tempfile.NamedTemporaryFile(delete=False)
-        answersfile.write("[general]\n")
-        answersfile.write("version: " + version + "\n")
-        answersfile.write("dest_dir: /etc/rhui/confrpm\n")
-        answersfile.write("qpid_ca: /etc/rhui/qpid/ca.crt\n")
-        answersfile.write("qpid_client: /etc/rhui/qpid/client.crt\n")
-        answersfile.write("qpid_nss_db: /etc/rhui/qpid/nss\n")
-        instances = [rhuisetup.Instances["RHUA"][0]]
-        instances.extend(rhuisetup.Instances["CDS"])
-        cds_number = 1
-        if not capassword:
-            capassword = Util.get_ca_password(rhuisetup.Instances["RHUA"][0])
-        for instance in instances:
-            if instance.private_hostname:
-                hostname = instance.private_hostname
-            else:
-                hostname = instance.public_hostname
-            if generate_certs:
-                Expect.expect_retval(rhuisetup.Instances["RHUA"][0], "openssl genrsa -out /etc/rhui/pem/" + hostname + ".key 2048", timeout=60)
-                if instance == rhuisetup.Instances["RHUA"][0]:
-                    Expect.expect_retval(rhuisetup.Instances["RHUA"][0], "openssl req -new -key /etc/rhui/pem/" + hostname + ".key -subj \"/C=US/ST=NC/L=Raleigh/CN=" + hostname + "\" -out /etc/rhui/pem/" + hostname + ".csr", timeout=60)
-                else:
-                    # Create domain wildcard certificates for CDSes
-                    # otherwise CDS will not be accessible via public hostname
-                    Expect.expect_retval(rhuisetup.Instances["RHUA"][0], "openssl req -new -key /etc/rhui/pem/" + hostname + ".key -subj \"/C=US/ST=NC/L=Raleigh/CN=" + Util.wildcard(hostname) + "\" -out /etc/rhui/pem/" + hostname + ".csr", timeout=60)
-                Expect.expect_retval(rhuisetup.Instances["RHUA"][0], "openssl x509 -req -days 365 -CA /etc/rhui/pem/ca.crt -CAkey /etc/rhui/pem/ca.key -passin \"pass:" + capassword + "\" -in /etc/rhui/pem/" + hostname + ".csr -out /etc/rhui/pem/" + hostname + ".crt", timeout=60)
-            if instance == rhuisetup.Instances["RHUA"][0]:
-                answersfile.write("[rhua]\n")
-                if proxy_host:
-                    # Doing proxy setup
-                    answersfile.write("proxy_server_host: " + proxy_host + "\n")
-                    if proxy_port:
-                        answersfile.write("proxy_server_port: " + proxy_port + "\n")
-                    if proxy_user:
-                        answersfile.write("proxy_server_username: " + proxy_user + "\n")
-                    if proxy_password:
-                        answersfile.write("proxy_server_password: " + proxy_password + "\n")
-            else:
-                answersfile.write("[cds-" + str(cds_number) + "]\n")
-                cds_number += 1
-            answersfile.write("hostname: " + hostname + "\n")
-            answersfile.write("rpm_name: " + hostname + "\n")
-            answersfile.write("ssl_cert: /etc/rhui/pem/" + hostname + ".crt\n")
-            answersfile.write("ssl_key: /etc/rhui/pem/" + hostname + ".key\n")
-            answersfile.write("ca_cert: /etc/rhui/pem/ca.crt\n")
-        answersfile.close()
-        rhuisetup.Instances["RHUA"][0].sftp.put(answersfile.name, answersfile_name)


### PR DESCRIPTION
In this PR:
- setup of Atomic host via ansible
- fix of issue #49: repos used in tests are stored in separate file `tests/rhui3_tests/tested_repos.yaml`, when needed to change any, that file should be updated only, no need to go through all tests and update repos there
- tests for atomic and non-atomic cli are separated in different files, new tests added. Commented tests in `test_atomic_cli.py` are fine but it all will fail because of BZ #1427190.
- new functions: 
    - `RHUIManagerRepo.get_repo_version`  which is used to define _floating_ version of atomic repo particularly, 
    - `Utils.get_rhua_version` to check the major release version of RHUA host and run tests respectively,
    - `RHUIManagerSync.check_sync_started` to ensure the sync started
- updated functions: 
    - `RHUIManagerRepo.list` according to BZ #1393787
    - `RHUIManagerRepo.delete_all_repos` according to BZ #1391641
    -  `RHUIManagerEntitlements.upload_rh_certificate` adding uploaded cert as an argument
    -  adding handler on Error sync status in `RHUIManagerSync.wait_till_repo_synced`
    - replacing `Utils.install_rpm` with `Utils.install_pkg` to handle atomic and non atomic pkgs
- updated README files respectively to this PR
- corrected typos and removed trailing spaces

When `test_atomic_cli.py` runs on RHEL6 RHUA host: 

`*** Running test_atomic_client.py: *** `
`SKIP: Not supported on RHEL6`
`*** Finished running test_atomic_client.py. *** `

`----------------------------------------------------------------------`
`Ran 0 tests in 0.349s`

`OK (SKIP=1)`

Tested on RHEL7 only: 

`[root@test rhui3_tests]# nosetests -vs test_atomic_client.py` 
`*** Running test_atomic_client.py: *** `
`do initial rhui-manager run ... ok`
`add a CDS ... ok`
`add an HAProxy Load-balancer ... ok`
`upload atomic cert ... ok`
`add the RHEL RHUI Atomic 7 Ostree Repo ... ok`
`generate an entitlement certificate for the Atomic repo (RHEL 7+ only) ... ok`
`create an Atomic client configuration package (RHEL 7+ only) ... ok`
`install atomic pkg on atomic host ... ok`
`remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+), remove rpms from cli, uninstall cds, hap ... ok`
`*** Finished running test_atomic_client.py. *** `

`----------------------------------------------------------------------`
`Ran 9 tests in 769.454s`

`OK`

`[root@test rhui3_tests]# nosetests -vs test_client_management.py `
`*** Running test_client_management.py: *** `
`do initial rhui-manager run ... ok`
`upload a new or updated Red Hat content certificate ... ok`
`add a CDS ... ok`
`add an HAProxy Load-balancer ... ok`
`add a custom and RH content repos to protect by a cli entitlement cert, upload rpm, sync ... ok`
`generate an entitlement certificate ... ok`
`create a client configuration RPM from an entitlement certificate ... ok`
`remove amazon rhui configuration rpm from client ... ok`
`install configuration rpm to client ... ok`
`check client configuration rpm version ... ok`
`check if RH repos were synced to install rpm ... ok`
`install rpm from a custom repo ... ok`
`install rpm from a RH repo ... ok`
`create a docker client configuration RPM ... ok`
`install a docker client configuration RPM to client ... ok`
`check docker rpm version ... ok`
`remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+), remove rpms from cli, uninstall cds, hap ... ok`
`*** Finished running test_client_management.py. *** `

`----------------------------------------------------------------------`
`Ran 17 tests in 791.664s`

`OK`