### PR TITLE
Fix issue 59

### DIFF
--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -18,7 +18,7 @@ atomic_cli=stitches.connection.Connection("atomiccli.example.com", "root", "/roo
 with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
     doc = yaml.load(file)
 
-atomic_repo_name = doc['atomic_repo']['name']
+atomic_repo = doc['atomic_repo']['repo_name']
 
 class TestClient:
 
@@ -59,20 +59,20 @@ class TestClient:
         '''
            add the RHEL RHUI Atomic 7 Ostree Repo
         '''
-        RHUIManagerRepo.add_rh_repo_by_product(connection, [atomic_repo_name])
+        RHUIManagerRepo.add_rh_repo_by_product(connection, [atomic_repo])
 
     #def test_06_sync_atomic_repo(self):
     #    '''
     #       sync the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only)
     #    '''
     #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, atomic_repo_name)
-    #    RHUIManagerSync.sync_repo(connection, [atomic_repo_name + atomic_repo_version])
+    #    RHUIManagerSync.sync_repo(connection, [atomic_repo + " " + atomic_repo_version])
 
     def test_07_generate_atomic_ent_cert(self):
         '''
            generate an entitlement certificate for the Atomic repo (RHEL 7+ only)
         '''
-        RHUIManagerClient.generate_ent_cert(connection, [atomic_repo_name], "test_atomic_ent_cli", "/root/")
+        RHUIManagerClient.generate_ent_cert(connection, [atomic_repo], "test_atomic_ent_cli", "/root/")
         Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
         Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
 
@@ -89,8 +89,8 @@ class TestClient:
     #       check if Atomic repo was synced to pull the content (RHEL 7+ only)
     #    '''
     #    RHUIManager.initial_run(connection)
-    #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, atomic_repo_name)
-    #    RHUIManagerSync.wait_till_repo_synced(connection, atomic_repo_name + atomic_repo_version)
+    #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, atomic_repo)
+    #    RHUIManagerSync.wait_till_repo_synced(connection, atomic_repo + " " + atomic_repo_version)
 
     def test_10_install_atomic_pkg(self):
         '''

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -14,19 +14,14 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 cli=stitches.connection.Connection("cli01.example.com", "root", "/root/.ssh/id_rsa_test")
-atomic_cli=stitches.connection.Connection("atomiccli.example.com", "root", "/root/.ssh/id_rsa_test")
 
 with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
     doc = yaml.load(file)
 
-yum_repo1_name = doc['yum_repo1']['name']
-yum_repo1_version = doc['yum_repo1']['version']
-yum_repo2_name = doc['yum_repo2']['name']
-yum_repo2_version = doc['yum_repo2']['version']
-atomic_repo_name = doc['atomic_repo']['name']
-
-def setUp():
-    print "*** Running %s: *** " % basename(__file__)
+repo1_name = doc['yum_repo1']['repo_name']
+repo1_product = doc['yum_repo1']['product_name']
+repo2_name = doc['yum_repo2']['repo_name']
+repo2_product = doc['yum_repo2']['product_name']
 
 class TestClient:
 
@@ -68,17 +63,17 @@ class TestClient:
         '''
         RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
         RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
-        RHUIManagerRepo.add_rh_repo_by_repo(connection, [yum_repo1_name + yum_repo1_version + " \(Yum\)", yum_repo2_name + yum_repo2_version + " \(Yum\)"])
-        RHUIManagerSync.sync_repo(connection, [yum_repo1_name + yum_repo1_version, yum_repo2_name + yum_repo2_version])
+        RHUIManagerRepo.add_rh_repo_by_repo(connection, [repo1_name + " \(Yum\)", repo2_name + " \(Yum\)"])
+        RHUIManagerSync.sync_repo(connection, [repo1_name, repo2_name])
 
     def test_06_generate_ent_cert(self):
         '''
            generate an entitlement certificate
         '''
         if self.rhua_os_version < 7:
-           RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", yum_repo1_name], "test_ent_cli", "/root/")
+           RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", repo1_product], "test_ent_cli", "/root/")
         else:
-           RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", yum_repo2_name], "test_ent_cli", "/root/")
+           RHUIManagerClient.generate_ent_cert(connection, ["custom-i386-x86_64", repo2_product], "test_ent_cli", "/root/")
         Expect.ping_pong(connection, "test -f /root/test_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
         Expect.ping_pong(connection, "test -f /root/test_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
 
@@ -114,9 +109,9 @@ class TestClient:
         '''
         RHUIManager.initial_run(connection)
         if self.rhua_os_version < 7:
-            RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo1_name + yum_repo1_version])
+            RHUIManagerSync.wait_till_repo_synced(connection, [repo1_name])
         else:
-            RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo2_name + yum_repo2_version])
+            RHUIManagerSync.wait_till_repo_synced(connection, [repo2_name])
 
     def test_12_install_rpm_from_custom_repo(self):
         '''

--- a/tests/rhui3_tests/test_repo_managment.py
+++ b/tests/rhui3_tests/test_repo_managment.py
@@ -14,8 +14,8 @@ connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ss
 with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
     doc = yaml.load(file)
 
-yum_repo_name = doc['yum_repo1']['name']
-yum_repo_version = doc['yum_repo1']['version']
+repo_name = doc['yum_repo1']['repo_name']
+repo_product= doc['yum_repo1']['product_name']
 
 def setUp():
     print "*** Running %s: *** " % basename(__file__)
@@ -64,17 +64,17 @@ def test_07_remove_3_custom_repos():
 
 def test_08_add_rh_repo_by_repository():
     '''Add a RH repo by repository'''
-    RHUIManagerRepo.add_rh_repo_by_repo(connection, [yum_repo_name + yum_repo_version + " \(Yum\)"])
+    RHUIManagerRepo.add_rh_repo_by_repo(connection, [repo_name + " \(Yum\)"])
     nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
 def test_09_delete_one_repo():
     '''Remove a RH repo'''
-    RHUIManagerRepo.delete_repo(connection, [yum_repo_name + ".*"])
+    RHUIManagerRepo.delete_repo(connection, [repo_name + ".*"])
     nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
 def test_10_add_rh_repo_by_product():
     '''Add a RH repo by product'''
-    RHUIManagerRepo.add_rh_repo_by_product(connection, [yum_repo_name])
+    RHUIManagerRepo.add_rh_repo_by_product(connection, [repo_product])
     #nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
 def test_11_delete_repo():

--- a/tests/rhui3_tests/test_sync_managment.py
+++ b/tests/rhui3_tests/test_sync_managment.py
@@ -14,8 +14,7 @@ connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ss
 with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
     doc = yaml.load(file)
 
-yum_repo_name = doc['yum_repo1']['name']
-yum_repo_version = doc['yum_repo1']['version']
+repo_name = doc['yum_repo1']['repo_name']
 
 def setUp():
     print "*** Running %s: *** " % basename(__file__)
@@ -24,23 +23,23 @@ def test_01_setup():
     '''do rhui-manager login, upload RH cert, add a repo to sync '''
     RHUIManager.initial_run(connection)
     RHUIManagerEntitlements.upload_rh_certificate(connection)
-    RHUIManagerRepo.add_rh_repo_by_repo(connection, [yum_repo_name + yum_repo_version + " \(Yum\)"])
+    RHUIManagerRepo.add_rh_repo_by_repo(connection, [repo_name + " \(Yum\)"])
 
 def test_02_sync_repo():
     '''sync a RH repo '''
-    RHUIManagerSync.sync_repo(connection, [yum_repo_name + yum_repo_version])
+    RHUIManagerSync.sync_repo(connection, [repo_name])
 
 def test_03_check_sync_started():
     '''ensure that sync started'''
-    RHUIManagerSync.check_sync_started(connection, [yum_repo_name + yum_repo_version])
+    RHUIManagerSync.check_sync_started(connection, [repo_name])
 
 def test_04_wait_till_repo_synced():
     '''wait until repo is synced'''
-    RHUIManagerSync.wait_till_repo_synced(connection, [yum_repo_name + yum_repo_version])
+    RHUIManagerSync.wait_till_repo_synced(connection, [repo_name])
 
 def test_99_cleanup():
     '''remove the RH repo '''
-    RHUIManagerRepo.delete_repo(connection, [yum_repo_name + ".*"])
+    RHUIManagerRepo.delete_repo(connection, [repo_name + ".*"])
 
 def tearDown():
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -1,8 +1,10 @@
 yum_repo1:
-    name: "Red Hat Update Infrastructure 2 \\(RPMs\\)"
-    version: " \\(6Server-x86_64\\)"
+    repo_name: "Red Hat Update Infrastructure 2 \\(RPMs\\) \\(6Server-x86_64\\)"
+    product_name: "Red Hat Update Infrastructure 2 \\(RPMs\\)"
+    version: "Yum"
 yum_repo2:
-    name: "Red Hat Enterprise Linux for SAP \\(RHEL 7 Server\\) \\(RPMs\\) from RHUI"
-    version: " \\(7Server-x86_64\\)"
+    repo_name: "Red Hat Enterprise Linux for SAP \\(RHEL 7 Server\\) \\(RPMs\\) from RHUI \\(7Server-x86_64\\)"
+    product_name: "Red Hat Enterprise Linux for SAP \\(RHEL 7 Server\\) \\(RPMs\\) from RHUI"
+    version: "Yum"
 atomic_repo:
-    name: "Red Hat Enterprise Linux Atomic Host \\(Trees\\) from RHUI"
+    repo_name: "Red Hat Enterprise Linux Atomic Host \\(Trees\\) from RHUI"

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -120,7 +120,7 @@ class RHUIManagerRepo(object):
         RHUIManager.select(connection, repolist)
         repolist_mod = list(repolist)
         for repo in repolist:
-            repolist_mod.append(re.sub(" \\\\\([a-zA-Z0-9_-]*\\\\\) \\\\\(Yum\\\\\)", "", repo))
+            repolist_mod.append(re.sub(" \\\\\([a-zA-Z0-9_ \.-]*\\\\\) \\\\\((Yum|Atomic)\\\\\)", "", repo))
         RHUIManager.proceed_with_check(connection, "The following product repositories will be deployed:", repolist_mod)
         RHUIManager.quit(connection)
 
@@ -175,10 +175,8 @@ class RHUIManagerRepo(object):
         full_reponame = next((s for s in repolist if reponame in s), None)
         #return full_reponame
         # get its version
-        repo_version = re.sub('^.*\((.*?)\)[^\(]*$', '\g<1>', full_reponame)
-
-        #return repo_version
-        return " \(" + repo_version + "\)"
+        repo_version = re.findall(r'\(.+?\)', full_reponame)[-1]
+        return repo_version
 
     @staticmethod
     def delete_repo(connection, repolist):


### PR DESCRIPTION
I suggest to keep `repo_name` and `product_name` in  `tested_repos.yaml`. Then, a user doesn't need to concatenate all the (sub)strings of repo names. However, a user need to remember to add a `repo_type` to a `repo_name`