### PR TITLE
Check if awcli is installed and configured before trying to run aws.

### DIFF
--- a/scripts/get_list_of_amis.sh
+++ b/scripts/get_list_of_amis.sh
@@ -4,6 +4,16 @@
 # These AMIs do not change very often, but it's still handy to get them all at once instead of copy&pasting them from Amazon UI.
 # Requires a working aws client
 #
+which aws &> /dev/null
+if [ $? -gt 0 ]; then
+  echo "The aws client is not available. Please install package awscli."
+  exit 1
+fi
+if [ ! -s ~/.aws/credentials ]; then
+  echo "The aws client is not configured. Please run \`aws configure'."
+  exit 1
+fi
+#
 # Sample output of this script:
 #
 #u'us-east-1': {u'AMI': u'ami-9df7548b'},


### PR DESCRIPTION
The `get_list_of_amis.sh `script just runs `aws` without checking if this command is available. So on a system which is new to this, the output is:

```
$ ./scripts/get_list_of_amis.sh 
./scripts/get_list_of_amis.sh: line 28: aws: command not found
u'ap-northeast-1': {u'AMI': u''},
./scripts/get_list_of_amis.sh: line 28: aws: command not found
u'ap-northeast-2': {u'AMI': u''},
...
```

It's not clear what one should install. I figured out I needed to install `awscli`, but I would have appreciated the package name from the script.

Even with the package installed, one isn't ready to use the script:

```
$ ./scripts/get_list_of_amis.sh 
Unable to locate credentials. You can configure credentials by running "aws configure".
u'ap-northeast-1': {u'AMI': u''},
Unable to locate credentials. You can configure credentials by running "aws configure".
u'ap-northeast-2': {u'AMI': u''},
...
```

That's helpful, but I don't need to see that suggestion as many times as we have regions. The script might check if the aws client has its configuration file. It may not be able to validate the configuration, but checking if the file exists (and is non-empty) should be good enough in most cases.