### PR TITLE
Install pynacl using pip on RHEL 6.

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -56,8 +56,15 @@
   package: name=openssl-devel state=present enablerepo=*
   tags: tests
 
-- name: install tests
+- name: install tests if RHEL 6 (install pynacl, issue 336)
+  # https://github.com/pyca/pynacl/issues/336
+  shell: cd /tmp/rhui3-tests/tests && easy_install pip && pip install pynacl && python setup.py install
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
+  tags: tests
+
+- name: install tests if RHEL 7
   shell: cd /tmp/rhui3-tests/tests && python setup.py install
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
   tags: tests
 
 - name: generate ssh keys


### PR DESCRIPTION
Workaround for https://github.com/pyca/pynacl/issues/336.

Works fine on both RHEL 6 and 7.