### PR TITLE
Latest setuptools on RHEL 6

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -44,8 +44,12 @@
   package: name=python-devel state=present
   tags: tests
 
-- name: install python-setuptools
+- name: install distribution setuptools
   package: name=python-setuptools state=present
+  tags: tests
+
+- name: update to upstream setuptools
+  command: easy_install -U setuptools
   tags: tests
 
 - name: install libffi-devel

--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -56,15 +56,8 @@
   package: name=openssl-devel state=present enablerepo=*
   tags: tests
 
-- name: install tests if RHEL 6 (install pynacl, issue 336)
-  # https://github.com/pyca/pynacl/issues/336
-  shell: cd /tmp/rhui3-tests/tests && easy_install pip && pip install pynacl && python setup.py install
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
-  tags: tests
-
-- name: install tests if RHEL 7
+- name: install tests
   shell: cd /tmp/rhui3-tests/tests && python setup.py install
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
   tags: tests
 
 - name: generate ssh keys

--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -49,6 +49,7 @@
   tags: tests
 
 - name: update setuptools to the latest upstream version if RHEL 6
+  # workaround for https://github.com/pyca/pynacl/issues/336
   command: easy_install -U setuptools
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
   tags: tests

--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -44,12 +44,13 @@
   package: name=python-devel state=present
   tags: tests
 
-- name: install distribution setuptools
+- name: install python-setuptools
   package: name=python-setuptools state=present
   tags: tests
 
-- name: update to upstream setuptools
+- name: update setuptools to the latest upstream version if RHEL 6
   command: easy_install -U setuptools
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
   tags: tests
 
 - name: install libffi-devel

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -20,9 +20,7 @@ setup(name='rhui3_tests_lib',
         'rhui3_tests_lib'
         ],
     data_files=datafiles,
-#    install_requires=['nose>=1.3.0', 'stitches>=0.10'],
-#    setuptools==30.1.0 is a workaround for https://github.com/pypa/pip/issues/4104
-    install_requires=['nose>=1.3.0', 'stitches>=0.10', 'setuptools==30.1.0'],
+    install_requires=['nose>=1.3.0', 'stitches>=0.10'],
     zip_safe=False,
     classifiers=[
             'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -20,7 +20,7 @@ setup(name='rhui3_tests_lib',
         'rhui3_tests_lib'
         ],
     data_files=datafiles,
-    install_requires=['nose>=1.3.0', 'stitches>=0.10'],
+    install_requires=['nose>=1.3.0', 'stitches>=0.10', 'setuptools>=36.3.0'],
     zip_safe=False,
     classifiers=[
             'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -20,7 +20,7 @@ setup(name='rhui3_tests_lib',
         'rhui3_tests_lib'
         ],
     data_files=datafiles,
-    install_requires=['nose>=1.3.0', 'stitches>=0.10', 'setuptools>=36.3.0'],
+    install_requires=['nose>=1.3.0', 'stitches>=0.10'],
     zip_safe=False,
     classifiers=[
             'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',


### PR DESCRIPTION
This is an alternative (and IMHO better/less invasive) way to deal with the issue with pynacl on RHEL 6. These changes revert the previous changes and instead add a step in which the distribution-provided setuptools gets updated to the latest upstream version. This is only done on RHEL 6, though, as firstly it's impossible with the RHEL 7 python-setuptools package (I got a traceback), and secondly it's not even needed on RHEL 7.

The old workaround for pip issue 4104 in setup.py (setuptools==30.1.0 in install_requires) is no longer needed, so I'm removing it at the same time.

It took quite a few commits to get the the final and actually working solution, so please squash them into one with an appropriate log message, for example: Update setuptools to the latest upstream on RHEL 6.

Verified on both RHEL versions.