### PR TITLE
EXAMPLE - Don't merge: Install and use pip both on RHEL6 and RHEL7

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -56,15 +56,14 @@
   package: name=openssl-devel state=present enablerepo=*
   tags: tests
 
-- name: install tests if RHEL 6 (install pynacl, issue 336)
-  # https://github.com/pyca/pynacl/issues/336
-  shell: cd /tmp/rhui3-tests/tests && easy_install pip && pip install pynacl && python setup.py install
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
+- name: install pip if RHEL 6 or RHEL 7
+  shell: easy_install pip
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int in (6, 7)
   tags: tests
 
-- name: install tests if RHEL 7
-  shell: cd /tmp/rhui3-tests/tests && python setup.py install
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
+- name: install tests
+  shell: cd /tmp/rhui3-tests/tests && pip install .
+  when: ansible_os_family == "RedHat"
   tags: tests
 
 - name: generate ssh keys


### PR DESCRIPTION
Continuing the discussion started in pyca/pynacl#336 and completing #69, i'd suggest to install and use `pip` for deployment both under RHEL 6 and 7 .