### PR TITLE
Use pip to install rhui3-tests-lib and its deps.

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -56,15 +56,12 @@
   package: name=openssl-devel state=present enablerepo=*
   tags: tests
 
-- name: install tests if RHEL 6 (install pynacl, issue 336)
-  # https://github.com/pyca/pynacl/issues/336
-  shell: cd /tmp/rhui3-tests/tests && easy_install pip && pip install pynacl && python setup.py install
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
+- name: install pip
+  shell: easy_install pip
   tags: tests
 
-- name: install tests if RHEL 7
-  shell: cd /tmp/rhui3-tests/tests && python setup.py install
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
+- name: install tests
+  shell: cd /tmp/rhui3-tests/tests && pip install .
   tags: tests
 
 - name: generate ssh keys

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -2,6 +2,7 @@
 
 import re
 from os.path import basename
+import time
 
 from stitches.expect import Expect, ExpectFailed
 from rhui3_tests_lib.rhuimanager import RHUIManager


### PR DESCRIPTION
The test suite no longer works on RHEL 6 with the changes in branch latest_setuptools:

```
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/nose-1.3.7-py2.6.egg/nose/suite.py", line 209, in run
    self.setUp()
  File "/usr/lib/python2.6/site-packages/nose-1.3.7-py2.6.egg/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/usr/lib/python2.6/site-packages/nose-1.3.7-py2.6.egg/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/usr/lib/python2.6/site-packages/nose-1.3.7-py2.6.egg/nose/util.py", line 471, in try_run
    return func()
  File "/tmp/rhui3-tests/tests/rhui3_tests/test_client_management.py", line 35, in setUpClass
    cls.rhua_os_version = Util.get_rhua_version(connection)
  File "/tmp/rhui3-tests/tests/rhui3_tests_lib/util.py", line 132, in get_rhua_version
    stdin, stdout, stderr = connection.exec_command('grep -E -o "[0-9]" /etc/redhat-release | head -1')
  File "/usr/lib/python2.6/site-packages/stitches-0.11-py2.6.egg/stitches/connection.py", line 272, in exec_command
    return self.cli.exec_command(command, bufsize, get_pty=get_pty)
TypeError: exec_command() got an unexpected keyword argument 'get_pty'
```

To fix this issue, I'd like to obsolete the latest_setuptools branch and take the approach suggested in branch lmctv:use-pip, which means using pip, but without the RHEL 6/7 conditionals as we only care about RHEL 6 and 7 anyway.