### PR TITLE
require the last compatible paramiko version on RHEL 6

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -3,6 +3,14 @@
 from setuptools import setup
 import glob
 import os
+import sys
+
+requirements=['nose>=1.3.0', 'stitches>=0.10']
+
+# Workaround for https://github.com/paramiko/paramiko/issues/1123
+python_version=sys.version_info[0] + sys.version_info[1] / 10.0
+if python_version <= 2.6:
+    requirements.append('paramiko==2.3.1')
 
 datafiles = []
 for topdir in ['rhui3_tests']:
@@ -20,7 +28,7 @@ setup(name='rhui3_tests_lib',
         'rhui3_tests_lib'
         ],
     data_files=datafiles,
-    install_requires=['nose>=1.3.0', 'stitches>=0.10'],
+    install_requires=requirements,
     zip_safe=False,
     classifiers=[
             'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',


### PR DESCRIPTION
Version 2.4.0 of paramiko brought test formatting changes that only work with decently recent python versions (2.7+). Consequently, the RHUI 3 test suite can't run anymore. This commit works around that by requiring the previous paramiko version if python 2.6 or earlier is used, which is the case on RHEL 6.

Tested successfully. RHEL 6:
```
Collecting paramiko==2.3.1 (from rhui3-tests-lib==1.0)
  Downloading paramiko-2.3.1-py2.py3-none-any.whl (182kB)
    100% |████████████████████████████████| 184kB 3.0MB/s
...
# ls /usr/lib/python2.?/site-packages/paramiko* -d
/usr/lib/python2.6/site-packages/paramiko  /usr/lib/python2.6/site-packages/paramiko-2.3.1.dist-info
# cat /usr/lib/python2.?/site-packages/rhui3_tests_lib-1.0-py2.?.egg-info/requires.txt
nose>=1.3.0
stitches>=0.10
paramiko==2.3.1

```
RHEL 7:
```
Collecting paramiko>=1.10 (from stitches>=0.10->rhui3-tests-lib==1.0)
  Downloading paramiko-2.4.0-py2.py3-none-any.whl (192kB)
    100% |████████████████████████████████| 194kB 3.1MB/s
...
# ls /usr/lib/python2.?/site-packages/paramiko* -d
/usr/lib/python2.7/site-packages/paramiko  /usr/lib/python2.7/site-packages/paramiko-2.4.0.dist-info
# cat /usr/lib/python2.?/site-packages/rhui3_tests_lib-1.0-py2.?.egg-info/requires.txt
nose>=1.3.0
stitches>=0.10
```

Test suite is able to run on both RHEL versions.