### PR TITLE
include an expired certificate in the tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,7 @@ In addition, you need a ZIP file with the following files in the root of the arc
   * _Red Hat Enterprise Linux Atomic Host (Trees) from RHUI_
   * _Red Hat Enterprise Linux Atomic Host (Debug RPMs) from RHUI_
   * _Red Hat Enterprise Linux Atomic Host (RPMs) from RHUI_
+* `rhcert_expired.pem` — This must be an expired Red Hat content certificate.
 * `rhui-rpm-upload-test-1-1.noarch.rpm` — This package will be uploaded to a custom repository.
 * `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository.
 

--- a/tests/rhui3_tests/test_CLI.py
+++ b/tests/rhui3_tests/test_CLI.py
@@ -120,5 +120,12 @@ def test_22_cleanup():
     RHUIManager.remove_rh_certs(connection)
     Expect.ping_pong(connection, "rm -rf /tmp/atomic_and_my* ; ls /tmp/atomic_and_my* 2>&1", "No such file or directory")
 
+def test_23_upload_entitlement_certificate():
+    '''Bonus: Check expired certificate handling'''
+    # currently, an error occurs
+    RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_expired.pem", "An unexpected error has occurred during the last operation")
+    # a relevant traceback is logged, though; check it
+    Expect.ping_pong(connection, "tail -1 /root/.rhui/rhui.log", "InvalidOrExpiredCertificate")
+
 def tearDown():
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_entitlements.py
+++ b/tests/rhui3_tests/test_entitlements.py
@@ -1,6 +1,7 @@
 #! /usr/bin/python -tt
 
 import nose, unittest, stitches, logging, yaml
+from nose.tools import *
 
 from rhui3_tests_lib.rhuimanager import *
 from rhui3_tests_lib.rhuimanager_entitlement import *
@@ -76,6 +77,17 @@ def test_09_list_custom_entitlements():
     '''
     list = RHUIManagerEntitlements.list_custom_entitlements(connection)
     nose.tools.assert_equal(len(list), 0)
+
+def test_10_remove_existing_entitlement_certificates():
+    '''Clean up uploaded entitlement certificates'''
+    RHUIManager.remove_rh_certs(connection)
+
+@raises(BadCertificate)
+def test_11_upload_expired_certificate():
+    '''
+       upload an expired certificate, expect a proper refusal
+    '''
+    RHUIManagerEntitlements.upload_rh_certificate(connection, "/tmp/extra_rhui_files/rhcert_expired.pem")
 
 def tearDown():
     print "*** Finished running %s. *** " % basename(__file__)


### PR DESCRIPTION
OK, December is here and I've extended the test suite as planned. The CLI and the interactive mode differ in the way an expired certificate is handled, but the test cases are written in accordance with the current behavior (which is rather strange in the case of the CLI, so I've filed [RHBZ#1519862](https://bugzilla.redhat.com/show_bug.cgi?id=1519862) for that.).