### PR TITLE
check if RHUI 3 repos contain packages

### DIFF
--- a/tests/rhui3_tests/test_rhui_3_repos.py
+++ b/tests/rhui3_tests/test_rhui_3_repos.py
@@ -1,0 +1,32 @@
+import nose, stitches, logging
+from stitches.expect import Expect
+
+from os.path import basename
+
+logging.basicConfig(level=logging.DEBUG)
+
+connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+
+def setUp():
+    print "*** Running %s: *** " % basename(__file__)
+
+def test_01_install_wget():
+    '''
+        Make sure wget is installed on the RHUA
+    '''
+    Expect.expect_retval(connection, "yum -y install wget")
+
+def test_02_rhui_3_for_rhel_6_check():
+    '''
+        Check if the RHUI 3 packages for RHEL 6 are available
+    '''
+    Expect.expect_retval(connection, "test $(wget -q -O - --certificate /tmp/extra_rhui_files/rhcert.pem --ca-certificate /etc/rhsm/ca/redhat-uep.pem https://cdn.redhat.com/content/dist/rhel/rhui/server/6/6Server/x86_64/rhui/3/os/Packages/ | grep -c \"A HREF.*\.rpm\") -gt 90")
+
+def test_03_rhui_3_for_rhel_7_check():
+    '''
+        Check if the RHUI 3 packages for RHEL 7 are available
+    '''
+    Expect.expect_retval(connection, "test $(wget -q -O - --certificate /tmp/extra_rhui_files/rhcert.pem --ca-certificate /etc/rhsm/ca/redhat-uep.pem https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/x86_64/rhui/3/os/Packages/ | grep -c \"A HREF.*\.rpm\") -gt 90")
+
+def tearDown():
+    print "*** Finished running %s. *** " % basename(__file__)


### PR DESCRIPTION
In case the RHUI 3 repos lose their contents for some reason, which would break one of the supported installation methods and which has happened to the RHUI 2 repo in the past, this test has been created to verify that enough (>90) packages are present. The test doesn't add and sync the repos; instead, it utilizes the entitlement certificate to fetch the repositories' directory listings straight from Red Hat CDN, and counts the links to RPM files, which represent the RHUI 3 packages.

Output:

```
[root@test tests]# nosetests -vs rhui3_tests/test_rhui_3_repos.py 
*** Running test_rhui_3_repos.py: *** 
Make sure wget is installed on the RHUA ... ok
Check if the RHUI 3 packages for RHEL 6 are available ... ok
Check if the RHUI 3 packages for RHEL 7 are available ... ok
*** Finished running test_rhui_3_repos.py. *** 

----------------------------------------------------------------------
Ran 3 tests in 11.424s

OK
```