### PR TITLE
full repo sync in the CLI

### DIFF
--- a/tests/rhui3_tests/test_CLI.py
+++ b/tests/rhui3_tests/test_CLI.py
@@ -87,7 +87,7 @@ def test_15_no_unexpected_repos():
     RHUIManagerCLI.validate_repo_list(connection, [yum_repo_id_1, yum_repo_id_2, custom_repo_name])
 
 def test_16_start_syncing_repo():
-    '''Start syncing one of the repos'''
+    '''Sync one of the repos'''
     RHUIManagerCLI.repo_sync(connection, yum_repo_id_2, yum_repo_name_2)
 
 def test_17_repo_info():


### PR DESCRIPTION
Previously, repo sync was only initiated in the CLI test coverage, and then a five-second nap was taken. This was a quick and simple solution, but not ideal. Moreover, the subsequent test for the presence of a random package in the repo could have failed because the repo might not have finished syncing yet. This patch enhances the CLI test library by performing a complete sync (waiting for & expecting Success). As a result, the library is now robust.

Tested on RHEL 6 and 7 successfully.