### PR TITLE
include an incompatible certificate in the tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,7 @@ In addition, you need a ZIP file with the following files in the root of the arc
   * _Red Hat Enterprise Linux Atomic Host (Debug RPMs) from RHUI_
   * _Red Hat Enterprise Linux Atomic Host (RPMs) from RHUI_
 * `rhcert_expired.pem` — This must be an expired Red Hat content certificate.
+* `rhcert_incompatible.pem` — This must be a Red Hat content certificate containing one or more entitlements that are not compatible with RHUI (containing a non-RHUI repository path).
 * `rhui-rpm-upload-test-1-1.noarch.rpm` — This package will be uploaded to a custom repository.
 * `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository.
 

--- a/tests/rhui3_tests/test_CLI.py
+++ b/tests/rhui3_tests/test_CLI.py
@@ -125,6 +125,11 @@ def test_23_upload_expired_entitlement_certificate():
     # a relevant traceback is logged, though; check it
     Expect.ping_pong(connection, "tail -1 /root/.rhui/rhui.log", "InvalidOrExpiredCertificate")
 
+def test_24_upload_incompatible_entitlement_certificate():
+    '''Bonus #2: Check incompatible certificate handling'''
+    # an error message is printed right away
+    RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_incompatible.pem", "not compatible with the RHUI")
+
 def test_99_cleanup():
     '''Cleanup: Delete all repositories from RHUI (interactively; not currently supported by the CLI), remove certs and other files'''
     RHUIManagerRepo.delete_all_repos(connection)

--- a/tests/rhui3_tests/test_entitlements.py
+++ b/tests/rhui3_tests/test_entitlements.py
@@ -89,5 +89,12 @@ def test_11_upload_expired_certificate():
     '''
     RHUIManagerEntitlements.upload_rh_certificate(connection, "/tmp/extra_rhui_files/rhcert_expired.pem")
 
+@raises(IncompatibleCertificate)
+def test_12_upload_incompatible_certificate():
+    '''
+       upload an incompatible certificate, expect a proper refusal
+    '''
+    RHUIManagerEntitlements.upload_rh_certificate(connection, "/tmp/extra_rhui_files/rhcert_incompatible.pem")
+
 def tearDown():
     print "*** Finished running %s. *** " % basename(__file__)


### PR DESCRIPTION
I've got a certificate that contains repos which don't match the following pattern hard-coded in rhui-manager:

`VALID_URL_PATTERN = '*content/*/rhui/*'`

The cert can be used to verify that this pattern is still enforced, ie. that the rhui-manager really/still only accepts RHUI repos.

Tested on RHEL 6 and 7. Output (truncated):

```
[root@test rhui3_tests]# nosetests -vs test_CLI.py test_entitlements.py 
*** Running test_CLI.py: *** 
<snip>
Bonus: Check expired certificate handling ... ok
Bonus #2: Check incompatible certificate handling ... ok
Cleanup: Delete all repositories from RHUI (interactively; not currently supported by the CLI), remove certs and other files ... ok
*** Finished running test_CLI.py. *** 
*** Running test_entitlements.py: *** 
<snip>
upload an expired certificate, expect a proper refusal ... ok
upload an incompatible certificate, expect a proper refusal ... ok
*** Finished running test_entitlements.py. *** 

----------------------------------------------------------------------
Ran 37 tests in 169.901s

OK (SKIP=1)
```
