### PR TITLE
add and improve doc strings, some formal fixes

### DIFF
--- a/tests/rhui3_tests/test_CLI.py
+++ b/tests/rhui3_tests/test_CLI.py
@@ -15,11 +15,12 @@ logging.basicConfig(level=logging.DEBUG)
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 custom_repo_name = "my_custom_repo"
 
-class TestCLI():
+class TestCLI(object):
+    '''
+        class for CLI tests
+    '''
 
-    def setUp(self):
-        print "*** Running %s: *** " % basename(__file__)
-
+    def __init__(self):
         with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
             doc = yaml.load(file)
 
@@ -28,44 +29,60 @@ class TestCLI():
         self.yum_repo_name_2 = doc['CLI_repo2']['name']
         self.yum_repo_id_2 = doc['CLI_repo2']['id']
 
+    @staticmethod
+    def setup_class():
+        '''
+           announce the beginning of the test run
+        '''
+        print "*** Running %s: *** " % basename(__file__)
 
-    def test_01_initial_run(self):
+    @staticmethod
+    def test_01_initial_run():
         '''Do an initial rhui-manager run to make sure we are logged in'''
         RHUIManager.initial_run(connection)
 
-    def test_02_check_empty_repo_list(self):
+    @staticmethod
+    def test_02_check_empty_repo_list():
         '''Check if the repolist is empty (interactively; not currently supported by the CLI)'''
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_03_remove_existing_entitlement_certificates(self):
+    @staticmethod
+    def test_03_remove_existing_entitlement_certificates():
         '''Clean up uploaded entitlement certificates'''
         RHUIManager.remove_rh_certs(connection)
 
-    def test_04_create_custom_repo(self):
+    @staticmethod
+    def test_04_create_custom_repo():
         '''Create a custom repo for further testing (interactively; not currently supported by the CLI)'''
         RHUIManagerRepo.add_custom_repo(connection, custom_repo_name, entitlement="n")
 
-    def test_05_check_custom_repo(self):
+    @staticmethod
+    def test_05_check_custom_repo():
         '''Check if the custom repo was actually created'''
         RHUIManagerCLI.repo_list(connection, custom_repo_name, custom_repo_name)
 
-    def test_06_upload_rpm_to_custom_repo(self):
+    @staticmethod
+    def test_06_upload_rpm_to_custom_repo():
         '''Upload content to the custom repo'''
         RHUIManagerCLI.packages_upload(connection, custom_repo_name, "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
 
-    def test_07_check_package_in_custom_repo(self):
+    @staticmethod
+    def test_07_check_package_in_custom_repo():
         '''Check that the uploaded package is now in the repo'''
         RHUIManagerCLI.packages_list(connection, custom_repo_name, "rhui-rpm-upload-test-1-1.noarch.rpm")
 
-    def test_08_upload_entitlement_certificate(self):
+    @staticmethod
+    def test_08_upload_entitlement_certificate():
         '''Upload the Atomic (the small) entitlement certificate'''
         RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_atomic.pem", "Atomic")
 
-    def test_09_check_certificate_info(self):
+    @staticmethod
+    def test_09_check_certificate_info():
         '''Check certificate info for validity'''
         RHUIManagerCLI.cert_info(connection)
 
-    def test_10_check_certificate_expiration(self):
+    @staticmethod
+    def test_10_check_certificate_expiration():
         '''Check if the certificate expiration date is OK'''
         RHUIManagerCLI.cert_expiration(connection)
 
@@ -113,33 +130,42 @@ class TestCLI():
         repo_label_2 = self.yum_repo_id_2.replace("-x86_64", "")
         RHUIManagerCLI.client_cert(connection, [repo_label_1, repo_label_2], "atomic_and_my", 365, "/tmp")
 
-    def test_21_create_client_configuration_rpm(self):
+    @staticmethod
+    def test_21_create_client_configuration_rpm():
         '''Create a client configuration RPM'''
         RHUIManagerCLI.client_rpm(connection, "/tmp/atomic_and_my.key", "/tmp/atomic_and_my.crt", "1.0", "atomic_and_my", "/tmp", [custom_repo_name])
 
-    def test_22_ensure_gpgcheck_in_client_configuration(self):
+    @staticmethod
+    def test_22_ensure_gpgcheck_in_client_configuration():
         '''Ensure that GPG checking is enabled in the client configuration'''
         raise nose.exc.SkipTest('currently not enabled (RHBZ#1428756)')
         Expect.expect_retval(connection, "grep -q '^gpgcheck\s*=\s*1$' /tmp/atomic_and_my-1.0/build/BUILD/atomic_and_my-1.0/rh-cloud.repo")
 
-    def test_23_upload_expired_entitlement_certificate(self):
+    @staticmethod
+    def test_23_upload_expired_entitlement_certificate():
         '''Bonus: Check expired certificate handling'''
         # currently, an error occurs
         RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_expired.pem", "An unexpected error has occurred during the last operation")
         # a relevant traceback is logged, though; check it
         Expect.ping_pong(connection, "tail -1 /root/.rhui/rhui.log", "InvalidOrExpiredCertificate")
 
-    def test_24_upload_incompatible_entitlement_certificate(self):
+    @staticmethod
+    def test_24_upload_incompatible_entitlement_certificate():
         '''Bonus #2: Check incompatible certificate handling'''
         # an error message is printed right away
         RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_incompatible.pem", "not compatible with the RHUI")
 
-    def test_99_cleanup(self):
+    @staticmethod
+    def test_99_cleanup():
         '''Cleanup: Delete all repositories from RHUI (interactively; not currently supported by the CLI), remove certs and other files'''
         RHUIManagerRepo.delete_all_repos(connection)
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
         RHUIManager.remove_rh_certs(connection)
         Expect.ping_pong(connection, "rm -rf /tmp/atomic_and_my* ; ls /tmp/atomic_and_my* 2>&1", "No such file or directory")
 
-    def tearDown(self):
+    @staticmethod
+    def teardown_class():
+        '''
+           announce the end of the test run
+        '''
         print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -1,4 +1,4 @@
-'''Atomic Client tests'''
+'''Atomic client tests (RHEL 7+ only)'''
 
 import nose, stitches, logging, yaml
 
@@ -18,24 +18,35 @@ connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ss
 atomic_cli=stitches.connection.Connection("atomiccli.example.com", "root", "/root/.ssh/id_rsa_test")
 
 
-class TestClient:
+class TestClient(object):
+    '''
+       class for Atomic client tests
+    '''
 
-    def setUp(self):
+    def __init__(self):
         self.rhua_os_version = Util.get_rhua_version(connection)
-        print "*** Running %s: *** " % basename(__file__)
         if self.rhua_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL6\n*** Finished running %s. *** ' % basename(__file__))
+            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.rhua_os_version))
 
         with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
             doc = yaml.load(file)
 
         self.atomic_repo_name = doc['atomic_repo']['name']
 
-    def test_01_repo_setup(self):
+    @staticmethod
+    def setup_class():
+        '''
+           announce the beginning of the test run
+        '''
+        print "*** Running %s: *** " % basename(__file__)
+
+    @staticmethod
+    def test_01_repo_setup():
         '''do initial rhui-manager run'''
         RHUIManager.initial_run(connection)
 
-    def test_02_add_cds(self):
+    @staticmethod
+    def test_02_add_cds():
         '''
             add a CDS
         '''
@@ -43,7 +54,8 @@ class TestClient:
         nose.tools.assert_equal(cds_list, [])
         RHUIManagerInstance.add_instance(connection, "cds", "cds01.example.com")
 
-    def test_03_add_hap(self):
+    @staticmethod
+    def test_03_add_hap():
         '''
             add an HAProxy Load-balancer
         '''
@@ -51,7 +63,8 @@ class TestClient:
         nose.tools.assert_equal(hap_list, [])
         RHUIManagerInstance.add_instance(connection, "loadbalancers", "hap01.example.com")
 
-    def test_04_upload_atomic_cert(self):
+    @staticmethod
+    def test_04_upload_atomic_cert():
         '''
             upload atomic cert
         '''
@@ -66,22 +79,23 @@ class TestClient:
 
     #def test_06_sync_atomic_repo(self):
     #    '''
-    #       sync the RHEL RHUI Atomic 7 Ostree Repo (RHEL 7+ only)
+    #       sync the RHEL RHUI Atomic 7 Ostree Repo
     #    '''
     #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, self.atomic_repo_name)
     #    RHUIManagerSync.sync_repo(connection, [self.atomic_repo_name + atomic_repo_version])
 
     def test_07_generate_atomic_ent_cert(self):
         '''
-           generate an entitlement certificate for the Atomic repo (RHEL 7+ only)
+           generate an entitlement certificate for the Atomic repo
         '''
         RHUIManagerClient.generate_ent_cert(connection, [self.atomic_repo_name], "test_atomic_ent_cli", "/root/")
         Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.crt && echo SUCCESS", "[^ ]SUCCESS")
         Expect.ping_pong(connection, "test -f /root/test_atomic_ent_cli.key && echo SUCCESS", "[^ ]SUCCESS")
 
-    def test_08_create_atomic_pkg(self):
+    @staticmethod
+    def test_08_create_atomic_pkg():
         '''
-           create an Atomic client configuration package (RHEL 7+ only)
+           create an Atomic client configuration package
         '''
         RHUIManager.initial_run(connection)
         RHUIManagerClient.create_atomic_conf_pkg(connection, "/root", "test_atomic_pkg", "/root/test_atomic_ent_cli.crt", "/root/test_atomic_ent_cli.key")
@@ -89,27 +103,30 @@ class TestClient:
 
     #def test_09_check_sync_status_of_atomic_repo(self):
     #    '''
-    #       check if Atomic repo was synced to pull the content (RHEL 7+ only)
+    #       check if Atomic repo was synced to pull the content
     #    '''
     #    RHUIManager.initial_run(connection)
     #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, self.atomic_repo_name)
     #    RHUIManagerSync.wait_till_repo_synced(connection, self.atomic_repo_name + atomic_repo_version)
 
-    def test_10_install_atomic_pkg(self):
+    @staticmethod
+    def test_10_install_atomic_pkg():
         '''
            install atomic pkg on atomic host
         '''
         Util.install_pkg_from_rhua(connection, atomic_cli, "/root/test_atomic_pkg.tar.gz")
 
-    #def test_11_pull_atomic_content(self):
+    #@staticmethod
+    #def test_11_pull_atomic_content():
     #    '''
     #       pull atomic content
     #    '''
     #    Expect.ping_pong(atomic_cli, "sudo ostree pull rhui-rhel-rhui-atomic-7-ostree-repo:rhel-atomic-host/7/x86_64/standard && echo SUCCESS", "[^ ]SUCCESS")
 
-    def test_99_cleanup(self):
+    @staticmethod
+    def test_99_cleanup():
         '''
-           remove created repos, entitlements and custom cli rpms (and tar on RHEL 7+), remove rpms from cli, uninstall cds, hap, delete the RH cert
+           remove entitlements and custom cli tar, uninstall cds, hap, delete the RH cert
         '''
         RHUIManager.initial_run(connection)
         RHUIManagerRepo.delete_all_repos(connection)
@@ -122,5 +139,9 @@ class TestClient:
      #                                    && echo SUCCESS", "[^ ]SUCCESS")
         RHUIManager.remove_rh_certs(connection)
 
-    def tearDown(self):
+    @staticmethod
+    def teardown_class():
+        '''
+           announce the end of the test run
+        '''
         print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_cds.py
+++ b/tests/rhui3_tests/test_cds.py
@@ -14,13 +14,15 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-def setUp():
+def setup():
+    '''
+       announce the beginning of the test run
+    '''
     print "*** Running %s: *** " % basename(__file__)
 
 def test_01_initial_run():
     '''
-        log in into RHUI
-        see roles/tests/tasks/main.yml
+        log in to RHUI
     '''
     RHUIManager.initial_run(connection)
 
@@ -33,7 +35,7 @@ def test_02_list_empty_cds():
 
 def test_03_add_cds():
     '''
-        add two CDS
+        add two CDSs
     '''
     RHUIManagerInstance.add_instance(connection, "cds", "cds01.example.com")
     RHUIManagerInstance.add_instance(connection, "cds", "cds02.example.com")
@@ -60,7 +62,7 @@ def test_06_list_cds():
 
 def test_07_delete_cds():
     '''
-        delete both CDS
+        delete both CDSs
     '''
     RHUIManagerInstance.delete(connection, "cds", ["cds01.example.com", "cds02.example.com"])
 
@@ -71,5 +73,8 @@ def test_08_list_cds():
     cds_list = RHUIManagerInstance.list(connection, "cds")
     nose.tools.assert_equal(cds_list, [])
 
-def tearDown():
+def teardown():
+    '''
+       announce the end of the test run
+    '''
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_entitlements.py
+++ b/tests/rhui3_tests/test_entitlements.py
@@ -15,90 +15,112 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-class TestEntitlement:
+class TestEntitlement(object):
+    '''
+       class for entitlement tests
+    '''
 
-    def setUp(self):
+    @staticmethod
+    def setup_class():
+        '''
+           announce the beginning of the test run
+        '''
         print "*** Running %s: *** " % basename(__file__)
 
-    def test_01_initial_run(self):
+    @staticmethod
+    def test_01_initial_run():
         '''
-            log in into RHUI
-            see roles/tests/tasks/main.yml
+            log in to RHUI
         '''
         RHUIManager.initial_run(connection)
 
-    def test_02_list_rh_entitlements(self):
+    @staticmethod
+    def test_02_list_rh_entitlements():
         '''
            list Red Hat content certificate entitlements
         '''
         entitlements = RHUIManagerEntitlements.list_rh_entitlements(connection)
         nose.tools.eq_(isinstance(entitlements, list), True)
 
-    def test_03_list_custom_entitlements(self):
+    @staticmethod
+    def test_03_list_custom_entitlements():
         '''
            list custom content certificate entitlements, expect none
         '''
         list = RHUIManagerEntitlements.list_custom_entitlements(connection)
         nose.tools.assert_equal(len(list), 0)
 
-    def test_04_upload_rh_certificate(self):
+    @staticmethod
+    def test_04_upload_rh_certificate():
         '''
            upload a new or updated Red Hat content certificate
         '''
         list = RHUIManagerEntitlements.upload_rh_certificate(connection)
         nose.tools.assert_not_equal(len(list), 0)
 
-    def test_05_list_rh_entitlements(self):
+    @staticmethod
+    def test_05_list_rh_entitlements():
         '''
            list Red Hat content certificate entitlements
         '''
         entitlements = RHUIManagerEntitlements.list_rh_entitlements(connection)
         nose.tools.eq_(isinstance(entitlements, list), True)
 
-    def test_06_add_custom_repo(self):
+    @staticmethod
+    def test_06_add_custom_repo():
         '''
            add a custom repo to protect by a client entitlement certificate
         '''
         RHUIManagerRepo.add_custom_repo(connection, "custom-enttest", "", "", "1", "y")
 
-    def test_07_list_custom_entitlements(self):
+    @staticmethod
+    def test_07_list_custom_entitlements():
         '''
            list custom content certificate entitlements, expect one
         '''
         list = RHUIManagerEntitlements.list_custom_entitlements(connection)
         nose.tools.assert_equal(len(list), 1)
 
-    def test_08_remove_custom_repo(self):
+    @staticmethod
+    def test_08_remove_custom_repo():
         '''
            remove the custom repo
         '''
         RHUIManagerRepo.delete_repo(connection, ["custom-enttest"])
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_09_list_custom_entitlements(self):
+    @staticmethod
+    def test_09_list_custom_entitlements():
         '''
            list custom content certificate entitlements, expect none
         '''
         list = RHUIManagerEntitlements.list_custom_entitlements(connection)
         nose.tools.assert_equal(len(list), 0)
 
-    def test_10_remove_existing_entitlement_certificates(self):
-        '''Clean up uploaded entitlement certificates'''
+    @staticmethod
+    def test_10_remove_existing_entitlement_certificates():
+        '''
+            clean up uploaded entitlement certificates
+        '''
         RHUIManager.remove_rh_certs(connection)
 
-    @raises(BadCertificate)
-    def test_11_upload_expired_certificate(self):
+    @staticmethod
+    def test_11_upload_expired_certificate():
         '''
            upload an expired certificate, expect a proper refusal
         '''
-        RHUIManagerEntitlements.upload_rh_certificate(connection, "/tmp/extra_rhui_files/rhcert_expired.pem")
+        assert_raises(BadCertificate, RHUIManagerEntitlements.upload_rh_certificate, connection, "/tmp/extra_rhui_files/rhcert_expired.pem")
 
-    @raises(IncompatibleCertificate)
-    def test_12_upload_incompatible_certificate(self):
+    @staticmethod
+    def test_12_upload_incompatible_certificate():
         '''
            upload an incompatible certificate, expect a proper refusal
         '''
-        RHUIManagerEntitlements.upload_rh_certificate(connection, "/tmp/extra_rhui_files/rhcert_incompatible.pem")
+        assert_raises(IncompatibleCertificate, RHUIManagerEntitlements.upload_rh_certificate, connection, "/tmp/extra_rhui_files/rhcert_incompatible.pem")
 
-    def tearDown(self):
+    @staticmethod
+    def teardown_class():
+        '''
+           announce the end of the test run
+        '''
         print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_hap.py
+++ b/tests/rhui3_tests/test_hap.py
@@ -14,13 +14,15 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-def setUp():
+def setup():
+    '''
+       announce the beginning of the test run
+    '''
     print "*** Running %s: *** " % basename(__file__)
 
 def test_01_initial_run():
     '''
         log in to RHUI
-        see roles/tests/tasks/main.yml
     '''
     RHUIManager.initial_run(connection)
 
@@ -70,5 +72,8 @@ def test_08_list_hap():
     hap_list = RHUIManagerInstance.list(connection, "loadbalancers")
     nose.tools.assert_equal(hap_list, [])
 
-def tearDown():
+def teardown():
+    '''
+       announce the end of the test run
+    '''
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -1,5 +1,5 @@
 #! /usr/bin/python -tt
-''' This is a test '''
+''' Repository management tests '''
 
 import nose, unittest, stitches, logging, yaml
 
@@ -13,56 +13,74 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-class TestRepo():
+class TestRepo(object):
+    '''
+       class for repository manipulation tests
+    '''
 
-    def setUp(self):
-        print "*** Running %s: *** " % basename(__file__)
+    def __init__(self):
         with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
             doc = yaml.load(file)
 
         self.yum_repo_name = doc['yum_repo1']['name']
         self.yum_repo_version = doc['yum_repo1']['version']
 
-    def test_01_repo_setup(self):
+    @staticmethod
+    def setup_class():
+        '''
+           announce the beginning of the test run
+        '''
+        print "*** Running %s: *** " % basename(__file__)
+
+    @staticmethod
+    def test_01_repo_setup():
         '''Do initial rhui-manager run, upload RH cert'''
         RHUIManager.initial_run(connection)
         list = RHUIManagerEntitlements.upload_rh_certificate(connection)
         nose.tools.assert_not_equal(len(list), 0)
 
-    def test_02_check_empty_repo_list(self):
+    @staticmethod
+    def test_02_check_empty_repo_list():
         '''Check if the repolist is empty'''
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_03_create_3_custom_repos(self):
+    @staticmethod
+    def test_03_create_3_custom_repos():
         '''Create 3 custom repos (protected, unprotected, no RH GPG check) '''
         RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
         RHUIManagerRepo.add_custom_repo(connection, "custom-x86_64-x86_64", "", "custom/x86_64/x86_64", "1", "n")
         RHUIManagerRepo.add_custom_repo(connection, "custom-i386-i386", "", "custom/i386/i386", "1", "y", "", "n" )
 
-    def test_04_check_custom_repo_list(self):
+    @staticmethod
+    def test_04_check_custom_repo_list():
         '''Check if the repolist contains 3 custom repos'''
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), ['custom-i386-i386', 'custom-i386-x86_64', 'custom-x86_64-x86_64'])
 
-    def test_05_repo_id_uniqness(self):
+    @staticmethod
+    def test_05_repo_id_uniqness():
         '''Check that repo id is unique'''
         RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
 
-    def test_06_upload_rpm_to_custom_repo(self):
+    @staticmethod
+    def test_06_upload_rpm_to_custom_repo():
         '''Upload content to the custom repo'''
         RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
 
-    def test_06_01_upload_several_rpms_to_custom_repo(self):
+    @staticmethod
+    def test_06_01_upload_several_rpms_to_custom_repo():
         '''Upload several rpms to the custom repo from a directory'''
         RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/")
 
-    def test_06_02_check_for_package(self):
+    @staticmethod
+    def test_06_02_check_for_package():
         '''Check the packages list'''
         nose.tools.assert_equal(RHUIManagerRepo.check_for_package(connection, "custom-i386-x86_64", ""), ["rhui-rpm-upload-test-1-1.noarch.rpm", "rhui-rpm-upload-trial-1-1.noarch.rpm"])
         nose.tools.assert_equal(RHUIManagerRepo.check_for_package(connection, "custom-i386-x86_64", "rhui-rpm-upload-test"), ["rhui-rpm-upload-test-1-1.noarch.rpm"])
         nose.tools.assert_equal(RHUIManagerRepo.check_for_package(connection, "custom-i386-x86_64", "test"), [])
         nose.tools.assert_equal(RHUIManagerRepo.check_for_package(connection, "custom-x86_64-x86_64", ""), [])
 
-    def test_07_remove_3_custom_repos(self):
+    @staticmethod
+    def test_07_remove_3_custom_repos():
         '''Remove 3 custom repos'''
         RHUIManagerRepo.delete_repo(connection, ["custom-i386-x86_64", "custom-x86_64-x86_64", "custom-i386-i386"])
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
@@ -82,34 +100,43 @@ class TestRepo():
         RHUIManagerRepo.add_rh_repo_by_product(connection, [self.yum_repo_name])
         #nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_11_delete_repo(self):
+    @staticmethod
+    def test_11_delete_repo():
         '''Remove a RH repo'''
         RHUIManagerRepo.delete_all_repos(connection)
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_12_add_all_rh_repos(self):
+    @staticmethod
+    def test_12_add_all_rh_repos():
          '''Add all RH repos'''
          RHUIManagerRepo.add_rh_repo_all(connection)
          #nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_13_delete_all_repos(self):
+    @staticmethod
+    def test_13_delete_all_repos():
         '''Delete all repositories from RHUI'''
         RHUIManagerRepo.delete_all_repos(connection)
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_14_add_docker_container(self):
+    @staticmethod
+    def test_14_add_docker_container():
         '''Add a RH docker container'''
         RHUIManagerRepo.add_docker_container(connection, "rhcertification/redhat-certification", "", "RH Certification Docker")
         nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_15_delete_docker_container(self):
+    @staticmethod
+    def test_15_delete_docker_container():
         '''Delete a docker container'''
         RHUIManagerRepo.delete_all_repos(connection)
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-    def test_16_delete_rh_cert(self):
+    @staticmethod
+    def test_16_delete_rh_cert():
         '''Delete the RH cert'''
         RHUIManager.remove_rh_certs(connection)
 
-    def tearDown(self):
-        print "*** Finished running %s. *** " % basename(__file__)
+    @staticmethod
+    def teardown_class():
+        '''
+           announce the end of the test run
+        '''

--- a/tests/rhui3_tests/test_rhui_3_repos.py
+++ b/tests/rhui3_tests/test_rhui_3_repos.py
@@ -1,3 +1,5 @@
+''' RHUI 3 RPM availability tests'''
+
 import nose, stitches, logging
 from stitches.expect import Expect
 
@@ -7,26 +9,32 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-def setUp():
+def setup():
+    '''
+       announce the beginning of the test run
+    '''
     print "*** Running %s: *** " % basename(__file__)
 
 def test_01_install_wget():
     '''
-        Make sure wget is installed on the RHUA
+        make sure wget is installed on the RHUA
     '''
     Expect.expect_retval(connection, "yum -y install wget")
 
 def test_02_rhui_3_for_rhel_6_check():
     '''
-        Check if the RHUI 3 packages for RHEL 6 are available
+        check if the RHUI 3 packages for RHEL 6 are available
     '''
     Expect.expect_retval(connection, "test $(wget -q -O - --certificate /tmp/extra_rhui_files/rhcert.pem --ca-certificate /etc/rhsm/ca/redhat-uep.pem https://cdn.redhat.com/content/dist/rhel/rhui/server/6/6Server/x86_64/rhui/3/os/Packages/ | grep -c \"A HREF.*\.rpm\") -gt 90")
 
 def test_03_rhui_3_for_rhel_7_check():
     '''
-        Check if the RHUI 3 packages for RHEL 7 are available
+        check if the RHUI 3 packages for RHEL 7 are available
     '''
     Expect.expect_retval(connection, "test $(wget -q -O - --certificate /tmp/extra_rhui_files/rhcert.pem --ca-certificate /etc/rhsm/ca/redhat-uep.pem https://cdn.redhat.com/content/dist/rhel/rhui/server/7/7Server/x86_64/rhui/3/os/Packages/ | grep -c \"A HREF.*\.rpm\") -gt 90")
 
-def tearDown():
+def teardown():
+    '''
+       announce the end of the test run
+    '''
     print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_sync_management.py
+++ b/tests/rhui3_tests/test_sync_management.py
@@ -13,15 +13,24 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-class TestSync():
+class TestSync(object):
+    '''
+       class for repository synchronization tests
+    '''
 
-    def setUp(self):
-        print "*** Running %s: *** " % basename(__file__)
+    def __init__(self):
         with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
             doc = yaml.load(file)
 
         self.yum_repo_name = doc['yum_repo1']['name']
         self.yum_repo_version = doc['yum_repo1']['version']
+
+    @staticmethod
+    def setup_class():
+        '''
+           announce the beginning of the test run
+        '''
+        print "*** Running %s: *** " % basename(__file__)
 
     def test_01_setup(self):
         '''do rhui-manager login, upload RH cert, add a repo to sync '''
@@ -47,5 +56,9 @@ class TestSync():
         RHUIManagerRepo.delete_repo(connection, [self.yum_repo_name + ".*"])
         RHUIManager.remove_rh_certs(connection)
 
-    def tearDown(self):
+    @staticmethod
+    def teardown_class():
+        '''
+           announce the end of the test run
+        '''
         print "*** Finished running %s. *** " % basename(__file__)

--- a/tests/rhui3_tests/test_user_management.py
+++ b/tests/rhui3_tests/test_user_management.py
@@ -12,19 +12,21 @@ logging.basicConfig(level=logging.DEBUG)
 
 connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-def setUp():
+def setup():
+    '''
+       announce the beginning of the test run
+    '''
     print "*** Running %s: *** " % basename(__file__)
 
 def test_01_initial_run():
     '''
         TODO a test case for an initial password
-        see roles/tests/tasks/main.yml
     '''
     RHUIManager.initial_run(connection)
 
 def test_02_change_password():
     '''
-        change a user's password and logout
+        change a user's password and log out
     '''
     RHUIManager.screen(connection, "users")
     RHUIManager.change_user_password(connection, password = "new_rhui_pass")
@@ -32,13 +34,13 @@ def test_02_change_password():
 
 def test_03_login_with_new_pass():
     '''
-       login with a new password
+       log in with a new password
     '''
     RHUIManager.initial_run(connection, password = "new_rhui_pass")
 
 def test_04():
     '''
-        change a user's password back to the default one and logout
+        change a user's password back to the default one and log out
     '''
     RHUIManager.screen(connection, "users")
     RHUIManager.change_user_password(connection)
@@ -46,7 +48,7 @@ def test_04():
 
 def test_05_login_with_wrong_password():
     '''
-        BZ 1282522. Doing initial run with wrong password.
+        BZ 1282522. Doing initial run with the wrong password.
     '''
     Expect.enter(connection, "rhui-manager")
     Expect.expect(connection, ".*RHUI Username:.*")
@@ -55,6 +57,8 @@ def test_05_login_with_wrong_password():
     Expect.enter(connection, "wrong_pass")
     Expect.expect(connection, ".*Invalid login, please check the authentication credentials and try again.")
 
-def tearDown():
+def teardown():
+    '''
+       announce the end of the test run
+    '''
     print "*** Finished running %s. *** " % basename(__file__)
-


### PR DESCRIPTION
This commit makes sure doc strings are in each file, class, and method/function. It also defines the classes and methods the way it should be done (as per _pylint_ anyway), which among other things improves the way the messages from `setup`/`teardown` are printed, and moves the definitions of important variables from `setup` to `__init__`, where they belong. Lastly, it remakes the tests which are supposed to raise an exception so that _sphinx_ can process them.

Tested successfully. I also rebuilt the docs with these changes and they looked good.