### PR TITLE
test coverage for subscription management

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -65,8 +65,14 @@
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
   tags: tests
 
+- name: install pip 9.0.3 if RHEL 6 (the last compatible version)
+  shell: easy_install pip==9.0.3
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
+  tags: tests
+
 - name: install pip
   shell: easy_install pip
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
   tags: tests
 
 - name: install tests
@@ -112,6 +118,13 @@
   delegate_to: "{{ item }}"
   with_items: "{{ groups['RHUA']|default([]) }}"
   when: (extra_files is defined) and (upload_extra_files|success)
+  tags: tests
+
+- name: upload Red Hat credentials
+  copy: src="{{ rhaccount }}" dest=/tmp/extra_rhui_files/rhaccount.sh
+  delegate_to: "{{ item }}"
+  with_items: "{{ groups['RHUA']|default([]) }}"
+  when: rhaccount is defined
   tags: tests
 
 - name: run tests suite

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ Welcome to RHUI3 Test Plan!
    entitlements
    hap
    repo_management
+   subscription
    sync_management
    user_management
    

--- a/docs/subscription.rst
+++ b/docs/subscription.rst
@@ -1,0 +1,6 @@
+Subscription Management Tests
+=============================
+
+.. automodule:: rhui3_tests.test_subscription
+   :members:
+   :undoc-members:

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,17 +31,36 @@ In addition, you need a ZIP file with the following files in the root of the arc
 * `rhui-rpm-upload-test-1-1.noarch.rpm` — This package will be uploaded to a custom repository.
 * `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository.
 
+Lastly, in order for the subscription test to be able to run, you need a file with valid Red Hat credentials allowing access to RHUI. The file must look like this:
+
+```
+SM_USERNAME=login
+SM_PASSWORD=password
+```
+
+Replace `login` with your Red Hat login and `password` with your Red Hat password. Save the file in an appropriate location and give it an appropriate name; for example, `rhaccount.sh`. You can then keep the file this way if you are not worried that someone else could read it, or you can encrypt it using Ansible. To encrypt the file, use the following command in the directory holding the file:
+
+`ansible-vault encrypt rhaccount.sh`
+
+Enter an appropriate encryption password when prompted.
+
 Usage
 --------
-You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instances in the `[CLI]` and `[ATOMIC_CLI]` sections of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the required ZIP file as a parameter of the `--extra-vars` option.
+You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instances in the `[CLI]` and `[ATOMIC_CLI]` sections of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the `--extra-vars` switch with the required ZIP file as a parameter of the `extra-files` option and also the required credentials file as a parameter of the `rhaccount` option. If the credentials file is encrypted, you will have to either provide the encryption password interactively or store it in a separate file (however, if someone reads that file, they will be able to read your Red Hat credentials, too, so be careful where you store the file).
 
-To install _and run the whole test suite_ as part of the initial deployment or after a completed deployment, use the following command:
+To install _and run the whole test suite_ as part of the initial deployment or after a completed deployment, use either the following command if you would like to enter the encryption password by hand:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip"`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip" rhaccount=~/Path/To/rhaccount.sh --ask-vault-pass`
+
+Or the following command if you have stored the encryption password in a separate file:
+
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip" rhaccount=~/Path/To/rhaccount.sh --vault-password-file ~/Path/To/The/File/With/The/password`
+
+Beware, regardless of the command you use, the credentials file will be stored on the RHUA node, _unencrypted_, as `/tmp/extra_rhui_files/rhaccount.sh`.
 
 Provide any other optional variables described in the RHUI deployment Readme as needed.
 
-Note that it can take 30 to 60 minutes for all the test cases to run. If you only want to install the test machine, add `--skip-tags run_tests` on the command line.
+Note that it can take a few hours for all the test cases to run. If you only want to install the test machine, add `--skip-tags run_tests` on the command line.
 
 The framework will be installed in the `/tmp/rhui3-tests` directory on the TEST machine. The output of the tests will be stored in `/tmp/rhui3test.log` on the TEST machine.
 
@@ -53,7 +72,7 @@ Or log in to the TEST machine, become root, enter the `/tmp/rhui3-tests/` direct
 
 `nosetests -vs tests/rhui3_tests`
 
-To run only a single test case, or a subset of the available test cases, speficy the test case(s) as the corresponding `test_XYZ.py` file name(s) on the `nosetests -vs` command line instead of `tests/rhui3_tests`, which is the directory containing all the test cases. For example:
+To run only a single test case, or a subset of the available test cases, specify the test case(s) as the corresponding `test_XYZ.py` file name(s) on the `nosetests -vs` command line instead of `tests/rhui3_tests`, which is the directory containing all the test cases. For example:
 
 `nosetests -vs tests/rhui3_tests/test_client_management.py`
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -50,11 +50,11 @@ You can include the test stage in a RHUI 3 deployment by providing the address o
 
 To install _and run the whole test suite_ as part of the initial deployment or after a completed deployment, use either the following command if you would like to enter the encryption password by hand:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip" rhaccount=~/Path/To/rhaccount.sh --ask-vault-pass`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh" --ask-vault-pass`
 
 Or the following command if you have stored the encryption password in a separate file:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip" rhaccount=~/Path/To/rhaccount.sh --vault-password-file ~/Path/To/The/File/With/The/password`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh" --vault-password-file ~/Path/To/The/File/With/The/password`
 
 Beware, regardless of the command you use, the credentials file will be stored on the RHUA node, _unencrypted_, as `/tmp/extra_rhui_files/rhaccount.sh`.
 

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -28,7 +28,7 @@ def test_01_register_system():
         register with RHSM
     '''
     Expect.expect_retval(CONNECTION, "source /tmp/extra_rhui_files/rhaccount.sh && " +
-                         "subscription-manager register --type=rhui "+
+                         "subscription-manager register --type=rhui " +
                          "--username=$SM_USERNAME --password=$SM_PASSWORD",
                          timeout=40)
 

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -1,0 +1,73 @@
+""" Test case for the RHUI SKU and the RHUI 3 repo """
+
+from os.path import basename
+
+import logging
+import stitches
+from stitches.expect import Expect
+from rhui3_tests_lib.util import Util
+
+logging.basicConfig(level=logging.DEBUG)
+
+CONNECTION = stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+
+def setup():
+    '''
+        announce the beginning of the test run
+    '''
+    print("*** Running %s: *** " % basename(__file__))
+
+def test_00_update_subman():
+    '''
+        make sure subscription-manager is up to date
+    '''
+    Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
+
+def test_01_register_system():
+    '''
+        register with RHSM
+    '''
+    Expect.expect_retval(CONNECTION, "source /tmp/extra_rhui_files/rhaccount.sh && " +
+                         "subscription-manager register --type=rhui "+
+                         "--username=$SM_USERNAME --password=$SM_PASSWORD",
+                         timeout=40)
+
+def test_02_attach_rhui_sku():
+    '''
+        check if the RHUI SKU is available and attach it if so
+    '''
+    Expect.expect_retval(CONNECTION, "subscription-manager list --available --matches=RC1116415 " +
+                         "--pool-only > /tmp/rhuipool.txt && " +
+                         "test -s /tmp/rhuipool.txt && " +
+                         "[[ \"$(cat /tmp/rhuipool.txt)\" =~ ^[0-9a-f]+$ ]] && " +
+                         "subscription-manager attach --pool=$(< /tmp/rhuipool.txt)",
+                         timeout=30)
+
+def test_03_enable_rhui_3_repo():
+    '''
+        enable the RHUI 3 repo
+    '''
+    rhel_version = Util.get_rhua_version(CONNECTION)
+    # the RHUI 3 for RHEL 6 repo tends to be unavailable with the test account :/ try using beta
+    if rhel_version == 6:
+        Expect.expect_retval(CONNECTION, "subscription-manager repos " +
+                             "--enable=rhel-6-server-rhui-3-rpms || " +
+                             "subscription-manager repos --enable=rhel-6-server-rhui-3-beta-rpms",
+                             timeout=60)
+    else:
+        Expect.expect_retval(CONNECTION, "subscription-manager repos --enable=rhel-" +
+                             str(rhel_version) + "-server-rhui-3-rpms",
+                             timeout=30)
+
+def test_04_unregister_system():
+    '''
+        unregister from RHSM
+    '''
+    Expect.expect_retval(CONNECTION, "rm -f /tmp/rhuipool.txt")
+    Expect.expect_retval(CONNECTION, "subscription-manager unregister")
+
+def teardown():
+    '''
+        announce the end of the test run
+    '''
+    print("*** Finished running %s. *** " % basename(__file__))


### PR DESCRIPTION
See the updated readme for instructions on how to use the new test case.

Tested on RHEL 6 and 7.

Docs updated. Tested.

Also note that pip has just been upgraded to a version which is no longer compatible with Python 2.6 (affects RHEL 6), so I've added a workaround for that at the same time.