### PR TITLE
prevent cloud-init from ruining /etc/resolv.conf on reboot

### DIFF
--- a/deploy/roles/atomic_cli/tasks/main.yml
+++ b/deploy/roles/atomic_cli/tasks/main.yml
@@ -2,7 +2,7 @@
 # file: roles/atomic_cli/tasks/main.yml
 # main atomic cli role tasks
 - name: set hostname
-  command: hostname "atomiccli.example.com"
+  hostname: name="atomiccli.example.com"
   with_indexed_items: "{{ groups['ATOMIC_CLI'] }}"
   when: "'ATOMIC_CLI' in groups"
   tags: atomic_cli

--- a/deploy/roles/common/tasks/cloud-init.yml
+++ b/deploy/roles/common/tasks/cloud-init.yml
@@ -1,0 +1,17 @@
+---
+# file: roles/common/tasks/cloud-init.yml
+# prevent cloud-init from running as it breaks our custom resolv.conf after rebooting
+
+- name: remove cloud-init on RHEL 6-
+  package:
+    name: cloud-init
+    state: absent
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int <= 6
+  tags: tame_cloud_init
+
+- name: keep cloud-init from starting on RHEL 7+
+  file:
+    path: /etc/cloud/cloud-init.disabled
+    state: touch
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
+  tags: tame_cloud_init

--- a/deploy/roles/common/tasks/main.yml
+++ b/deploy/roles/common/tasks/main.yml
@@ -2,7 +2,9 @@
 # file roles/common/tasks/main.yml
 # set up & configure ntp on all the hosts
 # set up custom DNS if requested
+# disable (or remove) cloud-init
 - include: upgrade_all_pkg.yml
 - include: ntp.yml
 - include: hosts.yml
 - include: dns_override.yml
+- include: cloud-init.yml


### PR DESCRIPTION
resolves https://github.com/RedHatQE/rhui3-automation/issues/64

So, here's how to achieve that:

- On RHEL 7, create `/etc/cloud/cloud-init.disabled`, which the cloud-init unit files consider a mechanism to disable starting.
- On RHEL 6, there are no such unit files and also an older version of cloud-init, so the only way is to uninstall cloud-init completely.
- For Atomic, the solution for RHEL 7 also applies, but previously the hostname was set using the `hostname` command, which meant that it wasn't a persistent change. I'm replacing the command with the hostname module, as used with all the other nodes.

Tested successfully.

Usage note: Should anyone want to leave cloud-init alone, they can use `--skip-tags tame_cloud_init` on the `ansible-playbook` command line.