### PR TITLE
test coverage for subscription registration in RHUI

### DIFF
--- a/tests/rhui3_tests/test_CLI.py
+++ b/tests/rhui3_tests/test_CLI.py
@@ -2,18 +2,29 @@
 
 #! /usr/bin/python -tt
 
-import nose, stitches, logging, yaml
+import logging
+from os.path import basename, join
+import re
+from shutil import rmtree
+from tempfile import mkdtemp
 
-from rhui3_tests_lib.rhuimanager import *
-from rhui3_tests_lib.rhuimanager_repo import *
-from rhui3_tests_lib.rhuimanagercli import *
+import nose
+import stitches
+from stitches.expect import Expect
+import yaml
 
-from os.path import basename
+from rhui3_tests_lib.rhuimanager import RHUIManager
+from rhui3_tests_lib.rhuimanager_repo import RHUIManagerRepo
+from rhui3_tests_lib.rhuimanagercli import RHUIManagerCLI
+from rhui3_tests_lib.subscription import RHSMRHUI
 
 logging.basicConfig(level=logging.DEBUG)
 
-connection=stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
-custom_repo_name = "my_custom_repo"
+CONNECTION = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+CUSTOM_REPO_NAME = "my_custom_repo"
+TMPDIR = mkdtemp()
+AVAILABLE_POOL_FILE = join(TMPDIR, "available")
+REGISTERED_POOL_FILE = join(TMPDIR, "registered")
 
 class TestCLI(object):
     '''
@@ -21,13 +32,14 @@ class TestCLI(object):
     '''
 
     def __init__(self):
-        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
-            doc = yaml.load(file)
+        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+            doc = yaml.load(configfile)
 
         self.yum_repo_name_1 = doc['CLI_repo1']['name']
         self.yum_repo_id_1 = doc['CLI_repo1']['id']
         self.yum_repo_name_2 = doc['CLI_repo2']['name']
         self.yum_repo_id_2 = doc['CLI_repo2']['id']
+        self.subscription_name_1 = doc['subscription1']['name']
 
     @staticmethod
     def setup_class():
@@ -39,128 +51,187 @@ class TestCLI(object):
     @staticmethod
     def test_01_initial_run():
         '''Do an initial rhui-manager run to make sure we are logged in'''
-        RHUIManager.initial_run(connection)
+        RHUIManager.initial_run(CONNECTION)
 
     @staticmethod
     def test_02_check_empty_repo_list():
         '''Check if the repolist is empty (interactively; not currently supported by the CLI)'''
-        nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
+        nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
 
     @staticmethod
     def test_03_remove_existing_entitlement_certificates():
         '''Clean up uploaded entitlement certificates'''
-        RHUIManager.remove_rh_certs(connection)
+        RHUIManager.remove_rh_certs(CONNECTION)
 
     @staticmethod
     def test_04_create_custom_repo():
         '''Create a custom repo for further testing (interactively; not currently supported by the CLI)'''
-        RHUIManagerRepo.add_custom_repo(connection, custom_repo_name, entitlement="n")
+        RHUIManagerRepo.add_custom_repo(CONNECTION, CUSTOM_REPO_NAME, entitlement="n")
 
     @staticmethod
     def test_05_check_custom_repo():
         '''Check if the custom repo was actually created'''
-        RHUIManagerCLI.repo_list(connection, custom_repo_name, custom_repo_name)
+        RHUIManagerCLI.repo_list(CONNECTION, CUSTOM_REPO_NAME, CUSTOM_REPO_NAME)
 
     @staticmethod
     def test_06_upload_rpm_to_custom_repo():
         '''Upload content to the custom repo'''
-        RHUIManagerCLI.packages_upload(connection, custom_repo_name, "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
+        RHUIManagerCLI.packages_upload(CONNECTION, CUSTOM_REPO_NAME, "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
 
     @staticmethod
     def test_07_check_package_in_custom_repo():
         '''Check that the uploaded package is now in the repo'''
-        RHUIManagerCLI.packages_list(connection, custom_repo_name, "rhui-rpm-upload-test-1-1.noarch.rpm")
+        RHUIManagerCLI.packages_list(CONNECTION, CUSTOM_REPO_NAME, "rhui-rpm-upload-test-1-1.noarch.rpm")
 
     @staticmethod
     def test_08_upload_entitlement_certificate():
         '''Upload the Atomic (the small) entitlement certificate'''
-        RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_atomic.pem", "Atomic")
+        RHUIManagerCLI.cert_upload(CONNECTION, "/tmp/extra_rhui_files/rhcert_atomic.pem", "Atomic")
 
     @staticmethod
     def test_09_check_certificate_info():
         '''Check certificate info for validity'''
-        RHUIManagerCLI.cert_info(connection)
+        RHUIManagerCLI.cert_info(CONNECTION)
 
     @staticmethod
     def test_10_check_certificate_expiration():
         '''Check if the certificate expiration date is OK'''
-        RHUIManagerCLI.cert_expiration(connection)
+        RHUIManagerCLI.cert_expiration(CONNECTION)
 
     def test_11_check_unused_product(self):
         '''Check if a repo is available'''
-        RHUIManagerCLI.repo_unused(connection, self.yum_repo_name_1)
+        RHUIManagerCLI.repo_unused(CONNECTION, self.yum_repo_name_1)
 
     def test_12_add_rh_repo_by_product(self):
         '''Add a Red Hat repo by its product name'''
-        RHUIManagerCLI.repo_add(connection, self.yum_repo_name_1)
+        RHUIManagerCLI.repo_add(CONNECTION, self.yum_repo_name_1)
 
     def test_13_add_rh_repo_by_id(self):
         '''Add a Red Hat repo by its ID'''
-        RHUIManagerCLI.repo_add_by_repo(connection, [self.yum_repo_id_2])
+        RHUIManagerCLI.repo_add_by_repo(CONNECTION, [self.yum_repo_id_2])
 
     def test_14_repo_list(self):
         '''Check the added repos'''
-        RHUIManagerCLI.repo_list(connection, self.yum_repo_id_1, self.yum_repo_name_1)
-        RHUIManagerCLI.repo_list(connection, self.yum_repo_id_2, self.yum_repo_name_2)
+        RHUIManagerCLI.repo_list(CONNECTION, self.yum_repo_id_1, self.yum_repo_name_1)
+        RHUIManagerCLI.repo_list(CONNECTION, self.yum_repo_id_2, self.yum_repo_name_2)
 
     def test_15_no_unexpected_repos(self):
         '''Check if no stray repo was added'''
-        RHUIManagerCLI.validate_repo_list(connection, [self.yum_repo_id_1, self.yum_repo_id_2, custom_repo_name])
+        RHUIManagerCLI.validate_repo_list(CONNECTION, [self.yum_repo_id_1, self.yum_repo_id_2, CUSTOM_REPO_NAME])
 
     def test_16_start_syncing_repo(self):
         '''Sync one of the repos'''
-        RHUIManagerCLI.repo_sync(connection, self.yum_repo_id_2, self.yum_repo_name_2)
+        RHUIManagerCLI.repo_sync(CONNECTION, self.yum_repo_id_2, self.yum_repo_name_2)
 
     def test_17_repo_info(self):
         '''Verify that the repo name is part of the information about the specified repo ID'''
-        RHUIManagerCLI.repo_info(connection, self.yum_repo_id_2, self.yum_repo_name_2)
+        RHUIManagerCLI.repo_info(CONNECTION, self.yum_repo_id_2, self.yum_repo_name_2)
 
     def test_18_check_package_in_repo(self):
         '''Check a random package in the repo'''
-        RHUIManagerCLI.packages_list(connection, self.yum_repo_id_2, "ostree")
+        RHUIManagerCLI.packages_list(CONNECTION, self.yum_repo_id_2, "ostree")
 
     def test_19_list_labels(self):
         '''Check repo labels'''
         repo_label = self.yum_repo_id_1.replace("-x86_64", "")
-        RHUIManagerCLI.repo_labels(connection, repo_label)
+        RHUIManagerCLI.repo_labels(CONNECTION, repo_label)
 
     def test_20_generate_entitlement_certificate(self):
         '''Generate an entitlement certificate'''
         repo_label_1 = self.yum_repo_id_1.replace("-x86_64", "")
         repo_label_2 = self.yum_repo_id_2.replace("-x86_64", "")
-        RHUIManagerCLI.client_cert(connection, [repo_label_1, repo_label_2], "atomic_and_my", 365, "/tmp")
+        RHUIManagerCLI.client_cert(CONNECTION, [repo_label_1, repo_label_2], "atomic_and_my", 365, "/tmp")
 
     @staticmethod
     def test_21_create_client_configuration_rpm():
         '''Create a client configuration RPM'''
-        RHUIManagerCLI.client_rpm(connection, "/tmp/atomic_and_my.key", "/tmp/atomic_and_my.crt", "1.0", "atomic_and_my", "/tmp", [custom_repo_name])
+        RHUIManagerCLI.client_rpm(CONNECTION, "/tmp/atomic_and_my.key", "/tmp/atomic_and_my.crt", "1.0", "atomic_and_my", "/tmp", [CUSTOM_REPO_NAME])
 
     @staticmethod
     def test_22_ensure_gpgcheck_in_client_configuration():
         '''Ensure that GPG checking is enabled in the client configuration'''
-        Expect.expect_retval(connection, "grep -q '^gpgcheck\s*=\s*1$' /tmp/atomic_and_my-1.0/build/BUILD/atomic_and_my-1.0/rh-cloud.repo")
+        Expect.expect_retval(CONNECTION, r"grep -q '^gpgcheck\s*=\s*1$' /tmp/atomic_and_my-1.0/build/BUILD/atomic_and_my-1.0/rh-cloud.repo")
 
     @staticmethod
     def test_23_upload_expired_entitlement_certificate():
         '''Bonus: Check expired certificate handling'''
         # currently, an error occurs
-        RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_expired.pem", "An unexpected error has occurred during the last operation")
+        RHUIManagerCLI.cert_upload(CONNECTION, "/tmp/extra_rhui_files/rhcert_expired.pem", "An unexpected error has occurred during the last operation")
         # a relevant traceback is logged, though; check it
-        Expect.ping_pong(connection, "tail -1 /root/.rhui/rhui.log", "InvalidOrExpiredCertificate")
+        Expect.ping_pong(CONNECTION, "tail -1 /root/.rhui/rhui.log", "InvalidOrExpiredCertificate")
 
     @staticmethod
     def test_24_upload_incompatible_entitlement_certificate():
         '''Bonus #2: Check incompatible certificate handling'''
         # an error message is printed right away
-        RHUIManagerCLI.cert_upload(connection, "/tmp/extra_rhui_files/rhcert_incompatible.pem", "not compatible with the RHUI")
+        RHUIManagerCLI.cert_upload(CONNECTION, "/tmp/extra_rhui_files/rhcert_incompatible.pem", "not compatible with the RHUI")
+
+    @staticmethod
+    def test_25_register_system():
+        '''Register the system in RHSM, attach RHUI SKU'''
+        RHSMRHUI.register_system(CONNECTION)
+        RHSMRHUI.attach_rhui_sku(CONNECTION)
+
+    @staticmethod
+    def test_26_fetch_available_pool():
+        '''Fetch the available pool ID'''
+        available_pool = RHUIManagerCLI.subscriptions_list(CONNECTION, "available", True)
+        nose.tools.ok_(re.search(r'^[0-9a-f]+$', available_pool) is not None)
+        with open(AVAILABLE_POOL_FILE, "w") as apf:
+            apf.write(available_pool)
+
+    @staticmethod
+    def test_27_register_subscription():
+        '''Register the subscription using the fetched pool ID'''
+        with open(AVAILABLE_POOL_FILE) as apf:
+            available_pool = apf.read()
+        nose.tools.ok_(re.search(r'^[0-9a-f]+$', available_pool) is not None)
+        RHUIManagerCLI.subscriptions_register(CONNECTION, available_pool)
+
+    @staticmethod
+    def test_28_fetch_registered_pool():
+        '''Fetch the registered pool ID'''
+        registered_pool = RHUIManagerCLI.subscriptions_list(CONNECTION, "registered", True)
+        nose.tools.ok_(re.search(r'^[0-9a-f]+$', registered_pool) is not None)
+        with open(REGISTERED_POOL_FILE, "w") as rpf:
+            rpf.write(registered_pool)
+
+    @staticmethod
+    def test_29_compare_pools():
+        '''Check if the previously available and now registered pool IDs are the same'''
+        with open(AVAILABLE_POOL_FILE) as apf:
+            available_pool = apf.read()
+        with open(REGISTERED_POOL_FILE) as rpf:
+            registered_pool = rpf.read()
+        nose.tools.assert_equal(available_pool, registered_pool)
+
+    def test_30_check_reg_pool_for_rhui(self):
+        '''Check if the registered subscription's description is RHUI for CCSP'''
+        list_reg = RHUIManagerCLI.subscriptions_list(CONNECTION)
+        nose.tools.ok_(self.subscription_name_1 in list_reg,
+                       msg="Expected subscription not registered in RHUI! Got: " + list_reg)
+
+    @staticmethod
+    def test_31_unregister_subscription():
+        '''Remove the subscription from RHUI'''
+        with open(REGISTERED_POOL_FILE) as rpf:
+            registered_pool = rpf.read()
+        nose.tools.ok_(re.search(r'^[0-9a-f]+$', registered_pool) is not None)
+        RHUIManagerCLI.subscriptions_unregister(CONNECTION, registered_pool)
+
+    @staticmethod
+    def test_32_unregister_system():
+        '''Unregister the system from RHSM'''
+        RHSMRHUI.unregister_system(CONNECTION)
 
     @staticmethod
     def test_99_cleanup():
         '''Cleanup: Delete all repositories from RHUI (interactively; not currently supported by the CLI), remove certs and other files'''
-        RHUIManagerRepo.delete_all_repos(connection)
-        nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
-        RHUIManager.remove_rh_certs(connection)
-        Expect.ping_pong(connection, "rm -rf /tmp/atomic_and_my* ; ls /tmp/atomic_and_my* 2>&1", "No such file or directory")
+        RHUIManagerRepo.delete_all_repos(CONNECTION)
+        nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
+        RHUIManager.remove_rh_certs(CONNECTION)
+        Expect.ping_pong(CONNECTION, "rm -rf /tmp/atomic_and_my* ; ls /tmp/atomic_and_my* 2>&1", "No such file or directory")
+        rmtree(TMPDIR)
 
     @staticmethod
     def teardown_class():

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -1,73 +1,111 @@
-""" Test case for the RHUI SKU and the RHUI 3 repo """
-
-from os.path import basename
+""" Test case for the RHUI SKU, the RHUI 3 repo, and subscription registration in RHUI """
 
 import logging
+from os.path import basename
+
+import nose
 import stitches
 from stitches.expect import Expect
-from rhui3_tests_lib.util import Util
+import yaml
+
+from rhui3_tests_lib.rhuimanager_subman import RHUIManagerSubMan
+from rhui3_tests_lib.subscription import RHSMRHUI
 
 logging.basicConfig(level=logging.DEBUG)
 
-CONNECTION = stitches.connection.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+CONNECTION = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
-def setup():
+class TestSubscription(object):
     '''
-        announce the beginning of the test run
+        class for tests for subscription registration in RHUI
     '''
-    print("*** Running %s: *** " % basename(__file__))
 
-def test_00_update_subman():
-    '''
-        make sure subscription-manager is up to date
-    '''
-    Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
+    def __init__(self):
+        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+            doc = yaml.load(configfile)
+        self.subscription_name_1 = doc['subscription1']['name']
 
-def test_01_register_system():
-    '''
-        register with RHSM
-    '''
-    Expect.expect_retval(CONNECTION, "source /tmp/extra_rhui_files/rhaccount.sh && " +
-                         "subscription-manager register --type=rhui " +
-                         "--username=$SM_USERNAME --password=$SM_PASSWORD",
-                         timeout=40)
+    @staticmethod
+    def setup_class():
+        '''
+            announce the beginning of the test run
+        '''
+        print("*** Running %s: *** " % basename(__file__))
 
-def test_02_attach_rhui_sku():
-    '''
-        check if the RHUI SKU is available and attach it if so
-    '''
-    Expect.expect_retval(CONNECTION, "subscription-manager list --available --matches=RC1116415 " +
-                         "--pool-only > /tmp/rhuipool.txt && " +
-                         "test -s /tmp/rhuipool.txt && " +
-                         "[[ \"$(cat /tmp/rhuipool.txt)\" =~ ^[0-9a-f]+$ ]] && " +
-                         "subscription-manager attach --pool=$(< /tmp/rhuipool.txt)",
-                         timeout=30)
+    @staticmethod
+    def test_00_update_subman():
+        '''
+            make sure subscription-manager is up to date
+        '''
+        Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
 
-def test_03_enable_rhui_3_repo():
-    '''
-        enable the RHUI 3 repo
-    '''
-    rhel_version = Util.get_rhua_version(CONNECTION)
-    # the RHUI 3 for RHEL 6 repo tends to be unavailable with the test account :/ try using beta
-    if rhel_version == 6:
-        Expect.expect_retval(CONNECTION, "subscription-manager repos " +
-                             "--enable=rhel-6-server-rhui-3-rpms || " +
-                             "subscription-manager repos --enable=rhel-6-server-rhui-3-beta-rpms",
-                             timeout=60)
-    else:
-        Expect.expect_retval(CONNECTION, "subscription-manager repos --enable=rhel-" +
-                             str(rhel_version) + "-server-rhui-3-rpms",
-                             timeout=30)
+    @staticmethod
+    def test_01_register_system():
+        '''
+            register with RHSM
+        '''
+        RHSMRHUI.register_system(CONNECTION)
 
-def test_04_unregister_system():
-    '''
-        unregister from RHSM
-    '''
-    Expect.expect_retval(CONNECTION, "rm -f /tmp/rhuipool.txt")
-    Expect.expect_retval(CONNECTION, "subscription-manager unregister")
+    @staticmethod
+    def test_02_attach_rhui_sku():
+        '''
+            check if the RHUI SKU is available and attach it if so
+        '''
+        RHSMRHUI.attach_rhui_sku(CONNECTION)
 
-def teardown():
-    '''
-        announce the end of the test run
-    '''
-    print("*** Finished running %s. *** " % basename(__file__))
+    @staticmethod
+    def test_03_enable_rhui_3_repo():
+        '''
+            enable the RHUI 3 repo
+        '''
+        RHSMRHUI.enable_rhui_3_repo(CONNECTION)
+
+    def test_04_check_available_subs(self):
+        '''
+            check if the subscription available to RHUI is indeed RHUI for CCSP
+        '''
+        avail_sub = RHUIManagerSubMan.subscriptions_list(CONNECTION, "available")
+        nose.tools.assert_not_equal(len(avail_sub), 0)
+        nose.tools.assert_equal(self.subscription_name_1, avail_sub[0])
+
+    def test_05_register_sub_in_rhui(self):
+        '''
+            register the RHUI for CCSP subscription in RHUI
+        '''
+        RHUIManagerSubMan.subscriptions_register(CONNECTION, [self.subscription_name_1])
+
+    def test_06_check_registered_subs(self):
+        '''
+            check if the subscription is now tracked as registered
+        '''
+        reg_sub = RHUIManagerSubMan.subscriptions_list(CONNECTION, "registered")
+        nose.tools.assert_not_equal(len(reg_sub), 0)
+        nose.tools.assert_equal(self.subscription_name_1, reg_sub[0])
+
+    def test_07_unregister_sub_in_rhui(self):
+        '''
+            unregister the subscription in RHUI
+        '''
+        RHUIManagerSubMan.subscriptions_unregister(CONNECTION, [self.subscription_name_1])
+
+    @staticmethod
+    def test_08_check_registered_subs():
+        '''
+            check if the subscription is no longer tracked as registered
+        '''
+        reg_sub = RHUIManagerSubMan.subscriptions_list(CONNECTION, "registered")
+        nose.tools.assert_equal(len(reg_sub), 0)
+
+    @staticmethod
+    def test_09_unregister_system():
+        '''
+            unregister from RHSM
+        '''
+        RHSMRHUI.unregister_system(CONNECTION)
+
+    @staticmethod
+    def teardown_class():
+        '''
+            announce the end of the test run
+        '''
+        print("*** Finished running %s. *** " % basename(__file__))

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -14,3 +14,5 @@ CLI_repo1:
 CLI_repo2:
     name: "Red Hat Enterprise Linux Atomic Host (RPMs) from RHUI (x86_64)"
     id: "rhel-atomic-host-rhui-rpms-x86_64"
+subscription1:
+    name: "Red Hat Update Infrastructure and RHEL Add-Ons for Providers"

--- a/tests/rhui3_tests_lib/rhuimanager.py
+++ b/tests/rhui3_tests_lib/rhuimanager.py
@@ -140,14 +140,18 @@ class RHUIManager(object):
         '''
         Open specified rhui-manager screen
         '''
-        Expect.enter(connection, "rhui-manager")
-        Expect.expect(connection, "rhui \(home\) =>")
         if screen_name in ["repo", "cds", "loadbalancers", "sync", "identity", "users"]:
             key = screen_name[:1]
         elif screen_name == "client":
             key = "e"
         elif screen_name == "entitlements":
             key = "n"
+        elif screen_name == "subscriptions":
+            key = "sm"
+        else:
+            raise ValueError("Unsupported screen name: " + screen_name)
+        Expect.enter(connection, "rhui-manager")
+        Expect.expect(connection, "rhui \(home\) =>")
         Expect.enter(connection, key)
         Expect.expect(connection, "rhui \(" + screen_name + "\) =>")
 

--- a/tests/rhui3_tests_lib/rhuimanager_subman.py
+++ b/tests/rhui3_tests_lib/rhuimanager_subman.py
@@ -1,0 +1,62 @@
+""" Red Hat subscription registration in RHUI """
+
+import re
+
+from stitches.expect import Expect
+from rhui3_tests_lib.rhuimanager import RHUIManager
+
+class RHUIManagerSubMan(object):
+    '''
+    Represents -= Subscriptions Manager =- RHUI screen
+    '''
+    prompt = r'rhui \(subscriptions\) => '
+
+    @staticmethod
+    def subscriptions_list(connection, what):
+        '''
+        list registered or available subscriptions
+        '''
+        if what == "registered":
+            key = "l"
+        elif what == "available":
+            key = "a"
+        else:
+            raise ValueError("Unsupported list: " + what)
+
+        RHUIManager.screen(connection, "subscriptions")
+        Expect.enter(connection, key)
+        lines = Expect.match(connection, re.compile("(.*)" + RHUIManagerSubMan.prompt,
+                                                    re.DOTALL))[0]
+        sub_list = []
+        for line in lines.splitlines():
+            # subscription names are on lines that start with two spaces
+            if line[:2] == "  ":
+                sub_list.append(line.strip())
+        Expect.enter(connection, 'q')
+        return sub_list
+
+    @staticmethod
+    def subscriptions_register(connection, names):
+        '''
+        register a Red Hat subscription in RHUI
+        '''
+        RHUIManager.screen(connection, "subscriptions")
+        Expect.enter(connection, "r")
+        RHUIManager.select(connection, names)
+        RHUIManager.proceed_with_check(connection,
+                                       "The following subscriptions will be registered:",
+                                       names)
+        RHUIManager.quit(connection)
+
+    @staticmethod
+    def subscriptions_unregister(connection, names):
+        '''
+        unregister a Red Hat subscription from RHUI
+        '''
+        RHUIManager.screen(connection, "subscriptions")
+        Expect.enter(connection, "d")
+        RHUIManager.select(connection, names)
+        RHUIManager.proceed_with_check(connection,
+                                       "The following subscriptions will be unregistered:",
+                                       names)
+        RHUIManager.quit(connection)

--- a/tests/rhui3_tests_lib/rhuimanagercli.py
+++ b/tests/rhui3_tests_lib/rhuimanagercli.py
@@ -128,3 +128,35 @@ class RHUIManagerCLI(object):
         generate a client configuration RPM
         '''
         Expect.ping_pong(connection, "rhui-manager client rpm --private_key " + private_key + " --entitlement_cert " + entitlement_cert + " --rpm_version " + rpm_version + " --rpm_name " + rpm_name + " --dir " + dir + "%s" %(" --unprotected_repos " + ",".join(unprotected_repos) if len(unprotected_repos) > 0 else ""), "RPMs can be found at " + dir)
+
+    @staticmethod
+    def subscriptions_list(connection, what="registered", poolonly=False):
+        '''
+        list registered or available subscriptions, complete information or the pool ID only
+        '''
+        if what not in ["registered", "available"]:
+            raise ValueError("Unsupported list: " + what)
+        if poolonly:
+            poolswitch = " --pool-only"
+        else:
+            poolswitch = ""
+        _, stdout, _ = connection.exec_command("rhui-manager subscriptions list --" + what +
+                                               poolswitch)
+        with stdout as output:
+            sub_list = output.read()
+        # uncolorify to work around RHBZ#1577052
+        return Util.uncolorify(sub_list).strip()
+
+    @staticmethod
+    def subscriptions_register(connection, pool):
+        '''
+        register the subscription to RHUI
+        '''
+        Expect.expect_retval(connection, "rhui-manager subscriptions register --pool " + pool)
+
+    @staticmethod
+    def subscriptions_unregister(connection, pool):
+        '''
+        remove the subscription from RHUI
+        '''
+        Expect.expect_retval(connection, "rhui-manager subscriptions unregister --pool " + pool)

--- a/tests/rhui3_tests_lib/subscription.py
+++ b/tests/rhui3_tests_lib/subscription.py
@@ -1,0 +1,59 @@
+""" RHSM integration in RHUI """
+
+from stitches.expect import Expect
+from rhui3_tests_lib.util import Util
+
+class RHSMRHUI(object):
+    '''
+        Subscription management for RHUI
+    '''
+    @staticmethod
+    def register_system(connection):
+        '''
+            register with RHSM
+        '''
+        rhaccount_file = "/tmp/extra_rhui_files/rhaccount.sh"
+        if connection.recv_exit_status("test -f " + rhaccount_file) != 0:
+            raise OSError(rhaccount_file + " does not exist")
+        Expect.expect_retval(connection, "source " + rhaccount_file + " && " +
+                             "subscription-manager register --type=rhui " +
+                             "--username=$SM_USERNAME --password=$SM_PASSWORD",
+                             timeout=40)
+
+    @staticmethod
+    def attach_rhui_sku(connection):
+        '''
+            check if the RHUI SKU is available and attach it if so
+        '''
+        Expect.expect_retval(connection, "subscription-manager list --available " +
+                             "--matches=RC1116415 --pool-only > /tmp/rhuipool.txt && " +
+                             "test -s /tmp/rhuipool.txt && " +
+                             "[[ \"$(cat /tmp/rhuipool.txt)\" =~ ^[0-9a-f]+$ ]] && " +
+                             "subscription-manager attach --pool=$(< /tmp/rhuipool.txt)",
+                             timeout=60)
+
+    @staticmethod
+    def enable_rhui_3_repo(connection):
+        '''
+            enable the RHUI 3 repo
+        '''
+        rhel_version = Util.get_rhua_version(connection)
+        # the RHUI 3 for RHEL 6 repo tends to be unavailable with the test account :/ try using beta
+        if rhel_version == 6:
+            Expect.expect_retval(connection, "subscription-manager repos " +
+                                 "--enable=rhel-6-server-rhui-3-rpms || " +
+                                 "subscription-manager repos " +
+                                 "--enable=rhel-6-server-rhui-3-beta-rpms",
+                                 timeout=60)
+        else:
+            Expect.expect_retval(connection, "subscription-manager repos --enable=rhel-" +
+                                 str(rhel_version) + "-server-rhui-3-rpms",
+                                 timeout=30)
+
+    @staticmethod
+    def unregister_system(connection):
+        '''
+            unregister from RHSM
+        '''
+        Expect.expect_retval(connection, "rm -f /tmp/rhuipool.txt")
+        Expect.expect_retval(connection, "subscription-manager unregister", timeout=20)


### PR DESCRIPTION
This long commit:

- moves RHSM commands to a separate library so this functionality can be used by various test cases (`test_subscriptions.py` has been revamped)
- adds a new library for the new "sm" screen in rhui-manager
- adds library functions for the new "rhui-manager subscription" CLI commands to the CLI library
- adds test cases for this functionality in both the CLI and the interactive mode
- makes adjustments to the old code where needed

As I was extensively editing some parts of the code, I went ahead and improved it to comply with Python standards; notably:

- one import per line
- categorized and sorted imports
- no wildcard imports; import what you really need
- upper case for constants
- no bad whitespace
- no redefined built-ins
- r prefix for strings that contain "anomalous" backslashes

Consequently, _pylint_ is now **much** happier; newly written scripts (or added code snippets) are fully compliant and rated 10/10 on Python 3 and "almost 10" on Python 2 (just because of parentheses used with `print`). I'd like to continue with this endeavor as I touch the code in the future.

Affected test cases were tested successfully:

```
[root@test tests]# nosetests -vs rhui3_tests/test_subscription.py
*** Running test_subscription.py: *** 
make sure subscription-manager is up to date ... ok
register with RHSM ... ok
check if the RHUI SKU is available and attach it if so ... ok
enable the RHUI 3 repo ... ok
check if the subscription available to RHUI is indeed RHUI for CCSP ... ok
register the RHUI for CCSP subscription in RHUI ... ok
check if the subscription is now tracked as registered ... ok
unregister the subscription in RHUI ... ok
check if the subscription is no longer tracked as registered ... ok
unregister from RHSM ... ok
*** Finished running test_subscription.py. *** 

----------------------------------------------------------------------
Ran 10 tests in 79.569s

OK
[root@test tests]# nosetests -vs rhui3_tests/test_CLI.py
*** Running test_CLI.py: *** 
Do an initial rhui-manager run to make sure we are logged in ... ok
Check if the repolist is empty (interactively; not currently supported by the CLI) ... ok
Clean up uploaded entitlement certificates ... ok
Create a custom repo for further testing (interactively; not currently supported by the CLI) ... ok
Check if the custom repo was actually created ... ok
Upload content to the custom repo ... ok
Check that the uploaded package is now in the repo ... ok
Upload the Atomic (the small) entitlement certificate ... ok
Check certificate info for validity ... ok
Check if the certificate expiration date is OK ... ok
Check if a repo is available ... ok
Add a Red Hat repo by its product name ... ok
Add a Red Hat repo by its ID ... ok
Check the added repos ... ok
Check if no stray repo was added ... ok
Sync one of the repos ... ok
Verify that the repo name is part of the information about the specified repo ID ... ok
Check a random package in the repo ... ok
Check repo labels ... ok
Generate an entitlement certificate ... ok
Create a client configuration RPM ... ok
Ensure that GPG checking is enabled in the client configuration ... ok
Bonus: Check expired certificate handling ... ok
Bonus #2: Check incompatible certificate handling ... ok
Register the system in RHSM, attach RHUI SKU ... ok
Fetch the available pool ID ... ok
Register the subscription using the fetched pool ID ... ok
Fetch the registered pool ID ... ok
Check if the previously available and now registered pool IDs are the same ... ok
Check if the registered subscription's description is RHUI for CCSP ... ok
Remove the subscription from RHUI ... ok
Unregister the system from RHSM ... ok
Cleanup: Delete all repositories from RHUI (interactively; not currently supported by the CLI), remove certs and other files ... ok
*** Finished running test_CLI.py. *** 

----------------------------------------------------------------------
Ran 33 tests in 109.312s

OK
```

Lastly, since these changes affect the test plan, I also tried rebuilding the docs locally. It went fine and the updated docs looked OK.