### PR TITLE
return major.minor RHEL version of the RHUA

### DIFF
--- a/tests/rhui3_tests/test_CLI.py
+++ b/tests/rhui3_tests/test_CLI.py
@@ -172,7 +172,7 @@ class TestCLI(object):
         '''Register the system in RHSM, attach RHUI SKU'''
         # update subscription-manager first (due to RHBZ#1554482)
         rhua_os_version = Util.get_rhua_version(CONNECTION)
-        if rhua_os_version == 7:
+        if rhua_os_version == 7.5:
             Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
         RHSMRHUI.register_system(CONNECTION)
         RHSMRHUI.attach_rhui_sku(CONNECTION)

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -10,6 +10,7 @@ import yaml
 
 from rhui3_tests_lib.rhuimanager_subman import RHUIManagerSubMan
 from rhui3_tests_lib.subscription import RHSMRHUI
+from rhui3_tests_lib.util import Util
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -33,17 +34,14 @@ class TestSubscription(object):
         print("*** Running %s: *** " % basename(__file__))
 
     @staticmethod
-    def test_00_update_subman():
-        '''
-            make sure subscription-manager is up to date
-        '''
-        Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
-
-    @staticmethod
     def test_01_register_system():
         '''
             register with RHSM
         '''
+        # update subscription-manager first (due to RHBZ#1554482)
+        rhua_os_version = Util.get_rhua_version(CONNECTION)
+        if rhua_os_version == 7.5:
+            Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
         RHSMRHUI.register_system(CONNECTION)
 
     @staticmethod

--- a/tests/rhui3_tests_lib/subscription.py
+++ b/tests/rhui3_tests_lib/subscription.py
@@ -37,7 +37,7 @@ class RHSMRHUI(object):
         '''
             enable the RHUI 3 repo
         '''
-        rhel_version = Util.get_rhua_version(connection)
+        rhel_version = int(Util.get_rhua_version(connection))
         # the RHUI 3 for RHEL 6 repo tends to be unavailable with the test account :/ try using beta
         if rhel_version == 6:
             Expect.expect_retval(connection, "subscription-manager repos " +

--- a/tests/rhui3_tests_lib/util.py
+++ b/tests/rhui3_tests_lib/util.py
@@ -125,9 +125,13 @@ class Util(object):
         '''
         get RHUA os version
         '''
-        stdin, stdout, stderr = connection.exec_command('grep -E -o "[0-9]" /etc/redhat-release | head -1')
-        for line in  stdout:
-            return int(line)
+        _, stdout, _ = connection.exec_command(r"egrep -o '[0-9]+\.[0-9]+' /etc/redhat-release")
+        with stdout as output:
+            version = output.read()
+        try:
+            return float(version)
+        except ValueError:
+            return None
 
     @staticmethod
     def wildcard(hostname):


### PR DESCRIPTION
resolves https://github.com/RedHatQE/rhui3-automation/issues/99

Affected test cases (changed by this commit or using the enhanced method) still pass on RHEL 6 and 7; ie.:


- test_CLI.py
- test_atomic_client.py
- test_client_management.py
- test_subscription.py


The test cases that update SM if the version is 7.5 were tested with both the 7.5 SM packages (which got updated during the execution) and the z-stream packages (already updated beforehand); everything was okay in either scenario.