### PR TITLE
add tasks to check if rhui-manager can run

### DIFF
--- a/deploy/roles/rhua/tasks/main.yml
+++ b/deploy/roles/rhua/tasks/main.yml
@@ -21,3 +21,17 @@
   command: rhui-installer --rhua-hostname=rhua.example.com --remote-fs-server="{{ 'cds01.example.com:rhui_content_' + hostvars[groups['GLUSTER'][0]]['r'] }}" --remote-fs-type=glusterfs
   when: install_rhui_installer is success and 'GLUSTER' in groups and groups['GLUSTER']|length > 0
   tags: rhua
+
+- name: get the initial rhui-manager password
+  command: awk '/rhui_manager_password:/ { print $2 }' /etc/rhui-installer/answers.yaml
+  register: password
+  tags: rhua
+
+- name: check if rhui-manager can run
+  command: rhui-manager --username admin --password {{ password.stdout }} status
+  register: rhuimanagercmd
+  tags: rhua
+
+- name: print the output from rhui-manager
+  debug:
+    var: rhuimanagercmd.stdout


### PR DESCRIPTION
resolves https://github.com/RedHatQE/rhui3-automation/issues/17

grabs the initial password and runs `rhui-manager --username admin --password THE_PASSWORD status`

These lines are newly printed when the playbook is run:

```
TASK [rhua : get the initial rhui-manager password] ***
changed: [ec2-***.eu-west-1.compute.amazonaws.com]

TASK [rhua : check if rhui-manager can run] ***
changed: [ec2-***.eu-west-1.compute.amazonaws.com]

TASK [rhua : print the output from rhui-manager] ***
ok: [ec2-***.eu-west-1.compute.amazonaws.com] => {
    "rhuimanagercmd.stdout": "\u001b[0mEntitlement CA certificate expiration date = 2038-01-18T08:52:34Z  .... [  \u001b[92mOK\u001b[0m  ]\n0"
}

```