### PR TITLE
store repo info w/o formatting, let the code format stuff

### DIFF
--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -82,7 +82,7 @@ class TestClient(object):
     #       sync the RHEL RHUI Atomic 7 Ostree Repo
     #    '''
     #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, self.atomic_repo_name)
-    #    RHUIManagerSync.sync_repo(connection, [self.atomic_repo_name + " (" + atomic_repo_version] + ")")
+    #    RHUIManagerSync.sync_repo(connection, [Util.format_repo(self.atomic_repo_name, atomic_repo_version))
 
     def test_07_generate_atomic_ent_cert(self):
         '''
@@ -107,7 +107,7 @@ class TestClient(object):
     #    '''
     #    RHUIManager.initial_run(connection)
     #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, self.atomic_repo_name)
-    #    RHUIManagerSync.wait_till_repo_synced(connection, self.atomic_repo_name + " (" + atomic_repo_version + ")")
+    #    RHUIManagerSync.wait_till_repo_synced(connection, Util.format_repo(self.atomic_repo_name, atomic_repo_version))
 
     @staticmethod
     def test_10_install_atomic_pkg():

--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -82,7 +82,7 @@ class TestClient(object):
     #       sync the RHEL RHUI Atomic 7 Ostree Repo
     #    '''
     #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, self.atomic_repo_name)
-    #    RHUIManagerSync.sync_repo(connection, [self.atomic_repo_name + atomic_repo_version])
+    #    RHUIManagerSync.sync_repo(connection, [self.atomic_repo_name + " (" + atomic_repo_version] + ")")
 
     def test_07_generate_atomic_ent_cert(self):
         '''
@@ -107,7 +107,7 @@ class TestClient(object):
     #    '''
     #    RHUIManager.initial_run(connection)
     #    atomic_repo_version = RHUIManagerRepo.get_repo_version(connection, self.atomic_repo_name)
-    #    RHUIManagerSync.wait_till_repo_synced(connection, self.atomic_repo_name + atomic_repo_version)
+    #    RHUIManagerSync.wait_till_repo_synced(connection, self.atomic_repo_name + " (" + atomic_repo_version + ")")
 
     @staticmethod
     def test_10_install_atomic_pkg():

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -35,9 +35,11 @@ class TestClient(object):
 
         self.yum_repo1_name = doc['yum_repo1']['name']
         self.yum_repo1_version = doc['yum_repo1']['version']
+        self.yum_repo1_kind = doc['yum_repo1']['kind']
         self.yum_repo1_path = doc['yum_repo1']['path']
         self.yum_repo2_name = doc['yum_repo2']['name']
         self.yum_repo2_version = doc['yum_repo2']['version']
+        self.yum_repo2_kind = doc['yum_repo2']['kind']
         self.yum_repo2_path = doc['yum_repo2']['path']
 
     @staticmethod
@@ -85,15 +87,15 @@ class TestClient(object):
         RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
         RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
         RHUIManagerRepo.add_rh_repo_by_repo(connection,
-                                            [self.yum_repo1_name +
-                                             " (" + self.yum_repo1_version + ") (Yum)",
-                                             self.yum_repo2_name +
-                                             " (" + self.yum_repo2_version + ") (Yum)"])
+                                            [Util.format_repo(self.yum_repo1_name,
+                                                              self.yum_repo1_version,
+                                                              self.yum_repo1_kind),
+                                             Util.format_repo(self.yum_repo2_name,
+                                                              self.yum_repo2_version,
+                                                              self.yum_repo1_kind)])
         RHUIManagerSync.sync_repo(connection,
-                                  [self.yum_repo1_name +
-                                   " (" + self.yum_repo1_version + ")",
-                                   self.yum_repo2_name +
-                                   " (" + self.yum_repo2_version + ")"])
+                                  [Util.format_repo(self.yum_repo1_name, self.yum_repo1_version),
+                                   Util.format_repo(self.yum_repo2_name, self.yum_repo2_version)])
 
     def test_06_generate_ent_cert(self):
         '''
@@ -151,12 +153,12 @@ class TestClient(object):
         RHUIManager.initial_run(connection)
         if self.rhua_os_version < 7:
             RHUIManagerSync.wait_till_repo_synced(connection,
-                                                  [self.yum_repo1_name +
-                                                   " (" + self.yum_repo1_version + ")"])
+                                                  [Util.format_repo(self.yum_repo1_name,
+                                                                    self.yum_repo1_version)])
         else:
             RHUIManagerSync.wait_till_repo_synced(connection,
-                                                  [self.yum_repo2_name +
-                                                   " (" + self.yum_repo2_version + ")"])
+                                                  [Util.format_repo(self.yum_repo2_name,
+                                                                    self.yum_repo2_version)])
 
     @staticmethod
     def test_13_install_rpm_from_custom_repo():

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -84,8 +84,16 @@ class TestClient(object):
         '''
         RHUIManagerRepo.add_custom_repo(connection, "custom-i386-x86_64", "", "custom/i386/x86_64", "1", "y")
         RHUIManagerRepo.upload_content(connection, ["custom-i386-x86_64"], "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
-        RHUIManagerRepo.add_rh_repo_by_repo(connection, [self.yum_repo1_name + self.yum_repo1_version + " \(Yum\)", self.yum_repo2_name + self.yum_repo2_version + " \(Yum\)"])
-        RHUIManagerSync.sync_repo(connection, [self.yum_repo1_name + self.yum_repo1_version, self.yum_repo2_name + self.yum_repo2_version])
+        RHUIManagerRepo.add_rh_repo_by_repo(connection,
+                                            [self.yum_repo1_name +
+                                             " (" + self.yum_repo1_version + ") (Yum)",
+                                             self.yum_repo2_name +
+                                             " (" + self.yum_repo2_version + ") (Yum)"])
+        RHUIManagerSync.sync_repo(connection,
+                                  [self.yum_repo1_name +
+                                   " (" + self.yum_repo1_version + ")",
+                                   self.yum_repo2_name +
+                                   " (" + self.yum_repo2_version + ")"])
 
     def test_06_generate_ent_cert(self):
         '''
@@ -142,9 +150,13 @@ class TestClient(object):
         '''
         RHUIManager.initial_run(connection)
         if self.rhua_os_version < 7:
-            RHUIManagerSync.wait_till_repo_synced(connection, [self.yum_repo1_name + self.yum_repo1_version])
+            RHUIManagerSync.wait_till_repo_synced(connection,
+                                                  [self.yum_repo1_name +
+                                                   " (" + self.yum_repo1_version + ")"])
         else:
-            RHUIManagerSync.wait_till_repo_synced(connection, [self.yum_repo2_name + self.yum_repo2_version])
+            RHUIManagerSync.wait_till_repo_synced(connection,
+                                                  [self.yum_repo2_name +
+                                                   " (" + self.yum_repo2_version + ")"])
 
     @staticmethod
     def test_13_install_rpm_from_custom_repo():

--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -87,7 +87,9 @@ class TestRepo(object):
 
     def test_08_add_rh_repo_by_repository(self):
         '''Add a RH repo by repository'''
-        RHUIManagerRepo.add_rh_repo_by_repo(connection, [self.yum_repo_name + self.yum_repo_version + " \(Yum\)"])
+        RHUIManagerRepo.add_rh_repo_by_repo(connection,
+                                            [self.yum_repo_name +
+                                             " (" + self.yum_repo_version + ") (Yum)"])
         nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
     def test_09_delete_one_repo(self):

--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -6,6 +6,7 @@ import nose, unittest, stitches, logging, yaml
 from rhui3_tests_lib.rhuimanager import *
 from rhui3_tests_lib.rhuimanager_repo import *
 from rhui3_tests_lib.rhuimanager_entitlement import *
+from rhui3_tests_lib.util import Util
 
 from os.path import basename
 
@@ -24,6 +25,7 @@ class TestRepo(object):
 
         self.yum_repo_name = doc['yum_repo1']['name']
         self.yum_repo_version = doc['yum_repo1']['version']
+        self.yum_repo_kind = doc['yum_repo1']['kind']
 
     @staticmethod
     def setup_class():
@@ -87,9 +89,9 @@ class TestRepo(object):
 
     def test_08_add_rh_repo_by_repository(self):
         '''Add a RH repo by repository'''
-        RHUIManagerRepo.add_rh_repo_by_repo(connection,
-                                            [self.yum_repo_name +
-                                             " (" + self.yum_repo_version + ") (Yum)"])
+        RHUIManagerRepo.add_rh_repo_by_repo(connection, [Util.format_repo(self.yum_repo_name,
+                                                                          self.yum_repo_version,
+                                                                          self.yum_repo_kind)])
         nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
     def test_09_delete_one_repo(self):

--- a/tests/rhui3_tests/test_sync_management.py
+++ b/tests/rhui3_tests/test_sync_management.py
@@ -37,19 +37,26 @@ class TestSync(object):
         RHUIManager.initial_run(connection)
         list = RHUIManagerEntitlements.upload_rh_certificate(connection)
         nose.tools.assert_not_equal(len(list), 0)
-        RHUIManagerRepo.add_rh_repo_by_repo(connection, [self.yum_repo_name + self.yum_repo_version + " \(Yum\)"])
+        RHUIManagerRepo.add_rh_repo_by_repo(connection,
+                                            [self.yum_repo_name +
+                                             " (" + self.yum_repo_version + ") (Yum)"])
 
     def test_02_sync_repo(self):
         '''sync a RH repo '''
-        RHUIManagerSync.sync_repo(connection, [self.yum_repo_name + self.yum_repo_version])
+        RHUIManagerSync.sync_repo(connection, [self.yum_repo_name +
+                                               " (" + self.yum_repo_version + ")"])
 
     def test_03_check_sync_started(self):
         '''ensure that sync started'''
-        RHUIManagerSync.check_sync_started(connection, [self.yum_repo_name + self.yum_repo_version])
+        RHUIManagerSync.check_sync_started(connection,
+                                           [self.yum_repo_name +
+                                            " (" + self.yum_repo_version + ")"])
 
     def test_04_wait_till_repo_synced(self):
         '''wait until repo is synced'''
-        RHUIManagerSync.wait_till_repo_synced(connection, [self.yum_repo_name + self.yum_repo_version])
+        RHUIManagerSync.wait_till_repo_synced(connection,
+                                              [self.yum_repo_name +
+                                               " (" + self.yum_repo_version + ")"])
 
     def test_99_cleanup(self):
         '''remove the RH repo and cert'''

--- a/tests/rhui3_tests/test_sync_management.py
+++ b/tests/rhui3_tests/test_sync_management.py
@@ -6,6 +6,7 @@ from rhui3_tests_lib.rhuimanager import *
 from rhui3_tests_lib.rhuimanager_repo import *
 from rhui3_tests_lib.rhuimanager_sync import *
 from rhui3_tests_lib.rhuimanager_entitlement import *
+from rhui3_tests_lib.util import Util
 
 from os.path import basename
 
@@ -24,6 +25,7 @@ class TestSync(object):
 
         self.yum_repo_name = doc['yum_repo1']['name']
         self.yum_repo_version = doc['yum_repo1']['version']
+        self.yum_repo_kind = doc['yum_repo1']['kind']
 
     @staticmethod
     def setup_class():
@@ -37,26 +39,24 @@ class TestSync(object):
         RHUIManager.initial_run(connection)
         list = RHUIManagerEntitlements.upload_rh_certificate(connection)
         nose.tools.assert_not_equal(len(list), 0)
-        RHUIManagerRepo.add_rh_repo_by_repo(connection,
-                                            [self.yum_repo_name +
-                                             " (" + self.yum_repo_version + ") (Yum)"])
+        RHUIManagerRepo.add_rh_repo_by_repo(connection, [Util.format_repo(self.yum_repo_name,
+                                                                          self.yum_repo_version,
+                                                                          self.yum_repo_kind)])
 
     def test_02_sync_repo(self):
         '''sync a RH repo '''
-        RHUIManagerSync.sync_repo(connection, [self.yum_repo_name +
-                                               " (" + self.yum_repo_version + ")"])
+        RHUIManagerSync.sync_repo(connection, [Util.format_repo(self.yum_repo_name,
+                                                                self.yum_repo_version)])
 
     def test_03_check_sync_started(self):
         '''ensure that sync started'''
-        RHUIManagerSync.check_sync_started(connection,
-                                           [self.yum_repo_name +
-                                            " (" + self.yum_repo_version + ")"])
+        RHUIManagerSync.check_sync_started(connection, [Util.format_repo(self.yum_repo_name,
+                                                                         self.yum_repo_version)])
 
     def test_04_wait_till_repo_synced(self):
         '''wait until repo is synced'''
-        RHUIManagerSync.wait_till_repo_synced(connection,
-                                              [self.yum_repo_name +
-                                               " (" + self.yum_repo_version + ")"])
+        RHUIManagerSync.wait_till_repo_synced(connection, [Util.format_repo(self.yum_repo_name,
+                                                                            self.yum_repo_version)])
 
     def test_99_cleanup(self):
         '''remove the RH repo and cert'''

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -1,13 +1,16 @@
 yum_repo1:
     name: "Red Hat Update Infrastructure 2 (RPMs)"
     version: "6Server-x86_64"
+    kind: "Yum"
     path: "content/dist/rhel/rhui/server/6/6Server/x86_64/rhui/2/os"
 yum_repo2:
     name: "Red Hat Enterprise Linux for SAP (RHEL 7 Server) (RPMs) from RHUI"
     version: "7Server-x86_64"
+    kind: "Yum"
     path: "content/dist/rhel/rhui/server/7/7Server/x86_64/sap/os"
 atomic_repo:
     name: "Red Hat Enterprise Linux Atomic Host (Trees) from RHUI"
+    kind: "Atomic"
 CLI_repo1:
     name: "Red Hat Enterprise Linux Atomic Host (Debug RPMs) from RHUI"
     id: "rhel-atomic-host-rhui-debug-rpms-x86_64"

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -1,13 +1,13 @@
 yum_repo1:
-    name: "Red Hat Update Infrastructure 2 \\(RPMs\\)"
-    version: " \\(6Server-x86_64\\)"
+    name: "Red Hat Update Infrastructure 2 (RPMs)"
+    version: "6Server-x86_64"
     path: "content/dist/rhel/rhui/server/6/6Server/x86_64/rhui/2/os"
 yum_repo2:
-    name: "Red Hat Enterprise Linux for SAP \\(RHEL 7 Server\\) \\(RPMs\\) from RHUI"
-    version: " \\(7Server-x86_64\\)"
+    name: "Red Hat Enterprise Linux for SAP (RHEL 7 Server) (RPMs) from RHUI"
+    version: "7Server-x86_64"
     path: "content/dist/rhel/rhui/server/7/7Server/x86_64/sap/os"
 atomic_repo:
-    name: "Red Hat Enterprise Linux Atomic Host \\(Trees\\) from RHUI"
+    name: "Red Hat Enterprise Linux Atomic Host (Trees) from RHUI"
 CLI_repo1:
     name: "Red Hat Enterprise Linux Atomic Host (Debug RPMs) from RHUI"
     id: "rhel-atomic-host-rhui-debug-rpms-x86_64"

--- a/tests/rhui3_tests_lib/rhuimanager.py
+++ b/tests/rhui3_tests_lib/rhuimanager.py
@@ -45,9 +45,13 @@ class RHUIManager(object):
         Select list of items (multiple choice)
         '''
         for value in value_list:
-            match = Expect.match(connection, re.compile(".*-\s+([0-9]+)\s*:[^\n]*\s+" + value + "\s*\n.*for more commands:.*", re.DOTALL))
+            match = Expect.match(connection, re.compile(".*-\s+([0-9]+)\s*:[^\n]*\s+" +
+                                                        Util.esc_parentheses(value) +
+                                                        "\s*\n.*for more commands:.*", re.DOTALL))
             Expect.enter(connection, match[0])
-            match = Expect.match(connection, re.compile(".*x\s+([0-9]+)\s*:[^\n]*\s+" + value + "\s*\n.*for more commands:.*", re.DOTALL))
+            match = Expect.match(connection, re.compile(".*x\s+([0-9]+)\s*:[^\n]*\s+" +
+                                                        Util.esc_parentheses(value) +
+                                                        "\s*\n.*for more commands:.*", re.DOTALL))
             Expect.enter(connection, "l")
         Expect.enter(connection, "c")
 
@@ -125,8 +129,6 @@ class RHUIManager(object):
             val = val.strip()
             val = val.replace("\t", " ")
             val = ' '.join(val.split())
-            val = val.replace("(", "\(")
-            val = val.replace(")", "\)")
             if val != "" and not val in skip_list:
                 selected_clean.append(val)
         if sorted(selected_clean) != sorted(value_list):

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -121,7 +121,7 @@ class RHUIManagerRepo(object):
         RHUIManager.select(connection, repolist)
         repolist_mod = list(repolist)
         for repo in repolist:
-            repolist_mod.append(re.sub(" \([a-zA-Z0-9_-]*\) \(Yum\)", "", repo))
+            repolist_mod.append(re.sub(" \([a-zA-Z0-9_-]*\) \([a-zA-Z]*\)", "", repo))
         RHUIManager.proceed_with_check(connection, "The following product repositories will be deployed:", repolist_mod)
         RHUIManager.quit(connection)
 

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -72,7 +72,7 @@ class RHUIManagerRepo(object):
                     checklist.append("Custom GPG Keys: '" + custom_gpg + "'")
                 else:
                     Expect.enter(connection, "n")
-                    checklist.append("Custom GPG Keys: \(None\)")
+                    checklist.append("Custom GPG Keys: (None)")
             else:
                 Expect.enter(connection, "n")
                 checklist.append("GPG Check No")
@@ -121,7 +121,7 @@ class RHUIManagerRepo(object):
         RHUIManager.select(connection, repolist)
         repolist_mod = list(repolist)
         for repo in repolist:
-            repolist_mod.append(re.sub(" \\\\\([a-zA-Z0-9_-]*\\\\\) \\\\\(Yum\\\\\)", "", repo))
+            repolist_mod.append(re.sub(" \([a-zA-Z0-9_-]*\) \(Yum\)", "", repo))
         RHUIManager.proceed_with_check(connection, "The following product repositories will be deployed:", repolist_mod)
         RHUIManager.quit(connection)
 
@@ -178,8 +178,7 @@ class RHUIManagerRepo(object):
         # get its version
         repo_version = re.sub('^.*\((.*?)\)[^\(]*$', '\g<1>', full_reponame)
 
-        #return repo_version
-        return " \(" + repo_version + "\)"
+        return repo_version
 
     @staticmethod
     def delete_repo(connection, repolist):

--- a/tests/rhui3_tests_lib/rhuimanager_sync.py
+++ b/tests/rhui3_tests_lib/rhuimanager_sync.py
@@ -31,7 +31,7 @@ class RHUIManagerSync(object):
         '''
         RHUIManager.screen(connection, "sync")
         Expect.enter(connection, "dr")
-        reponame_quoted = reponame.replace(".", "\.")
+        reponame_quoted = Util.esc_parentheses(reponame)
         res = Expect.match(connection, re.compile(".*" + reponame_quoted + "\s*\r\n([^\n]*)\r\n.*", re.DOTALL), [1], 60)[0]
         connection.cli.exec_command("killall -s SIGINT rhui-manager")
         res = Util.uncolorify(res)

--- a/tests/rhui3_tests_lib/util.py
+++ b/tests/rhui3_tests_lib/util.py
@@ -147,3 +147,14 @@ class Util(object):
         regular expressions in Expect methods
         '''
         return name.replace("(", "\(").replace(")", "\)")
+
+    @staticmethod
+    def format_repo(name, version, kind=""):
+        '''
+        helper method to put together a repo name, version, and optionally kind
+        the way RHUI repos are called in rhui-manager
+        '''
+        repo = "{0} ({1})".format(name, version)
+        if kind:
+            repo += " ({0})".format(kind)
+        return repo


### PR DESCRIPTION
resolves https://github.com/RedHatQE/rhui3-automation/issues/58

With this commit, tested repos are stored exactly as they're called, without backslashes which where there to pre-format the names so they could be used in regular expressions directly, and repo versions are also stored in their pure form, without parentheses. Spaces and parentheses are added by the code when needed. All the logic that allows the names and versions to be used in Expect methods is now in the code, where it formally belongs. IOW, I'm moving the responsibility for escaping special characters from the stored data to the code that handles the data.

All the test cases are able to run after these changes.