### PR TITLE
return RHEL version as a dict with two integers

### DIFF
--- a/tests/rhui3_tests/test_CLI.py
+++ b/tests/rhui3_tests/test_CLI.py
@@ -172,7 +172,7 @@ class TestCLI(object):
         '''Register the system in RHSM, attach RHUI SKU'''
         # update subscription-manager first (due to RHBZ#1554482)
         rhua_os_version = Util.get_rhua_version(CONNECTION)
-        if rhua_os_version == 7.5:
+        if rhua_os_version["major"] == 7 and rhua_os_version["minor"] == 5:
             Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
         RHSMRHUI.register_system(CONNECTION)
         RHSMRHUI.attach_rhui_sku(CONNECTION)

--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -24,7 +24,7 @@ class TestClient(object):
     '''
 
     def __init__(self):
-        self.rhua_os_version = Util.get_rhua_version(connection)
+        self.rhua_os_version = Util.get_rhua_version(connection)["major"]
         if self.rhua_os_version < 7:
             raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.rhua_os_version))
 

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -28,7 +28,7 @@ class TestClient(object):
     '''
 
     def __init__(self):
-        self.rhua_os_version = Util.get_rhua_version(connection)
+        self.rhua_os_version = Util.get_rhua_version(connection)["major"]
 
         with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as file:
             doc = yaml.load(file)

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -46,7 +46,7 @@ class TestSubscription(object):
         '''
         # update subscription-manager first (due to RHBZ#1554482)
         rhua_os_version = Util.get_rhua_version(CONNECTION)
-        if rhua_os_version == 7.5:
+        if rhua_os_version["major"] == 7 and rhua_os_version["minor"] == 5:
             Expect.expect_retval(CONNECTION, "yum -y update subscription-manager", timeout=30)
         RHSMRHUI.register_system(CONNECTION)
 

--- a/tests/rhui3_tests_lib/subscription.py
+++ b/tests/rhui3_tests_lib/subscription.py
@@ -37,7 +37,7 @@ class RHSMRHUI(object):
         '''
             enable the RHUI 3 repo
         '''
-        rhel_version = int(Util.get_rhua_version(connection))
+        rhel_version = Util.get_rhua_version(connection)["major"]
         # the RHUI 3 for RHEL 6 repo tends to be unavailable with the test account :/ try using beta
         if rhel_version == 6:
             Expect.expect_retval(connection, "subscription-manager repos " +

--- a/tests/rhui3_tests_lib/util.py
+++ b/tests/rhui3_tests_lib/util.py
@@ -127,9 +127,10 @@ class Util(object):
         '''
         _, stdout, _ = connection.exec_command(r"egrep -o '[0-9]+\.[0-9]+' /etc/redhat-release")
         with stdout as output:
-            version = output.read()
+            version = output.read().strip().split(".")
         try:
-            return float(version)
+            version_dict = {"major": int(version[0]), "minor": int(version[1])}
+            return version_dict
         except ValueError:
             return None
 


### PR DESCRIPTION
resolves https://github.com/RedHatQE/rhui3-automation/issues/99 for good; see my comment from Tuesday in that issue for justification

all the affected test cases work after these changes