### PR TITLE
require the requests Python library explicitly

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -5,7 +5,7 @@ import glob
 import os
 import sys
 
-requirements=['nose>=1.3.0', 'stitches>=0.12']
+requirements=['nose>=1.3.0', 'requests', 'stitches>=0.12']
 
 # Workaround for https://github.com/paramiko/paramiko/issues/1123
 python_version=sys.version_info[0] + sys.version_info[1] / 10.0


### PR DESCRIPTION
This is needed when using Python 3 from the SCL repo in AWS, which doesn't have a Python-3 build of the requests library. Otherwise the client test case can't run.

By including the requests library among the requirements, pip makes sure this library is installed: if it's already in the system via a python-requests RPM, which is typical of Python 2 on RHEL 6 and 7, there's nothing to do. If the library is missing, pip installs it.