### PR TITLE
store docker container info in yaml

### DIFF
--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -26,6 +26,8 @@ class TestRepo(object):
         self.yum_repo_name = doc['yum_repo1']['name']
         self.yum_repo_version = doc['yum_repo1']['version']
         self.yum_repo_kind = doc['yum_repo1']['kind']
+        self.docker_container_name = doc['docker_container1']['name']
+        self.docker_container_displayname = doc['docker_container1']['displayname']
 
     @staticmethod
     def setup_class():
@@ -122,10 +124,12 @@ class TestRepo(object):
         RHUIManagerRepo.delete_all_repos(connection)
         nose.tools.assert_equal(RHUIManagerRepo.list(connection), [])
 
-    @staticmethod
-    def test_14_add_docker_container():
+    def test_14_add_docker_container(self):
         '''Add a RH docker container'''
-        RHUIManagerRepo.add_docker_container(connection, "rhcertification/redhat-certification", "", "RH Certification Docker")
+        RHUIManagerRepo.add_docker_container(connection,
+                                             self.docker_container_name,
+                                             "",
+                                             self.docker_container_displayname)
         nose.tools.assert_not_equal(RHUIManagerRepo.list(connection), [])
 
     @staticmethod

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -21,3 +21,6 @@ CLI_repo2:
     label: "rhel-atomic-host-rhui-rpms"
 subscription1:
     name: "Red Hat Update Infrastructure and RHEL Add-Ons for Providers"
+docker_container1:
+    name: "rhcertification/redhat-certification"
+    displayname: "RH Certification Docker"


### PR DESCRIPTION
I'd like to take the information about the docker container to test from test_repo_management.py and store it in the global yaml file with tested repos.

In the future I'm going to add tests to add & sync the container in RHUA and pull & check & remove it on the client, which means I'll be using the information in more than one test case, so it would be really nice to have that information in the config file as opposed to the test cases themselves.