### PR TITLE
make pylint happy with the CLI tests

### DIFF
--- a/docs/cmdline.rst
+++ b/docs/cmdline.rst
@@ -1,6 +1,6 @@
 RHUI CLI Tests
 ======================
 
-.. automodule:: rhui3_tests.test_CLI
+.. automodule:: rhui3_tests.test_cmdline
    :members:
    :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,10 +11,10 @@ Welcome to RHUI3 Test Plan!
    :maxdepth: 2
    :caption: Contents:
    
-   CLI
    atomic_client
    cds
    client_management
+   cmdline
    entitlements
    hap
    repo_management

--- a/tests/rhui3_tests_lib/rhuimanager_cmdline.py
+++ b/tests/rhui3_tests_lib/rhuimanager_cmdline.py
@@ -151,8 +151,8 @@ class RHUIManagerCLI(object):
         generate an entitlement certificate
         '''
         Expect.ping_pong(connection,
-                         "rhui-manager client cert --repo_label " + ",".join(repo_labels) + " " +
-                         "--name " + name + " --days " + str(days) + " --dir " + directory,
+                         "rhui-manager client cert --repo_label %s " % ",".join(repo_labels) +
+                         "--name %s --days %s --dir %s" % (name, str(days), directory),
                          "Entitlement certificate created at %s/%s.crt" % (directory, name))
 
     @staticmethod

--- a/tests/rhui3_tests_lib/rhuimanager_cmdline.py
+++ b/tests/rhui3_tests_lib/rhuimanager_cmdline.py
@@ -1,6 +1,9 @@
 """ RHUIManagerCLI functions """
 
-import nose, re, time
+import re
+import time
+
+import nose
 
 from stitches.expect import Expect
 from rhui3_tests_lib.util import Util
@@ -14,7 +17,9 @@ class RHUIManagerCLI(object):
         '''
         upload a new or updated Red Hat content certificate
         '''
-        Expect.ping_pong(connection, "rhui-manager cert upload --cert " + certificate_file, test_string)
+        Expect.ping_pong(connection,
+                         "rhui-manager cert upload --cert " + certificate_file,
+                         test_string)
 
     @staticmethod
     def cert_info(connection):
@@ -35,36 +40,52 @@ class RHUIManagerCLI(object):
         '''
         check if the certificate expiration date is OK
         '''
-        Expect.ping_pong(connection, "rhui-manager status", "Entitlement CA certificate expiration date.*OK")
+        Expect.ping_pong(connection,
+                         "rhui-manager status",
+                         "Entitlement CA certificate expiration date.*OK")
 
     @staticmethod
     def repo_add(connection, repo):
         '''
         add a repo specified by its product name
         '''
-        Expect.ping_pong(connection, "rhui-manager repo add --product_name \"" + repo + "\"", "Successfully added")
+        Expect.ping_pong(connection,
+                         "rhui-manager repo add --product_name \"" + repo + "\"",
+                         "Successfully added")
 
     @staticmethod
     def repo_add_by_repo(connection, repo_ids):
         '''
         add a repo specified by its ID
         '''
-        Expect.ping_pong(connection, "rhui-manager repo add_by_repo --repo_ids " + ",".join(repo_ids), "Successfully added")
+        Expect.ping_pong(connection,
+                         "rhui-manager repo add_by_repo --repo_ids " + ",".join(repo_ids),
+                         "Successfully added")
 
     @staticmethod
     def repo_list(connection, repo_id, repo_name):
         '''
         check if the given repo ID and name are listed
         '''
-        Expect.ping_pong(connection, "rhui-manager repo list", repo_id + " *:: " + Util.esc_parentheses(repo_name))
+        Expect.ping_pong(connection,
+                         "rhui-manager repo list",
+                         repo_id + " *:: " + Util.esc_parentheses(repo_name))
 
     @staticmethod
     def validate_repo_list(connection, repo_ids):
         '''
         check if only the given repo IDs are listed
         '''
-        Expect.expect_retval(connection, "rhui-manager repo list | grep -v 'ID.*Repository Name$' | grep :: | cut -d ' ' -f 1 | sort > /tmp/actual_repo_list && echo \"" + "\n".join(sorted(repo_ids)) + "\" > /tmp/expected_repo_list && cmp /tmp/actual_repo_list /tmp/expected_repo_list")
-        Expect.ping_pong(connection, "rm -f /tmp/*_repo_list ; ls /tmp/*_repo_list 2>&1", "No such file or directory")
+        Expect.expect_retval(connection,
+                             "rhui-manager repo list | " +
+                             "grep -v 'ID.*Repository Name$' | grep :: | cut -d ' ' -f 1 | " +
+                             "sort > /tmp/actual_repo_list && "
+                             "echo \"" + "\n".join(sorted(repo_ids)) + "\" > "
+                             "/tmp/expected_repo_list && " +
+                             "cmp /tmp/actual_repo_list /tmp/expected_repo_list")
+        Expect.ping_pong(connection,
+                         "rm -f /tmp/*_repo_list ; ls /tmp/*_repo_list 2>&1",
+                         "No such file or directory")
 
     @staticmethod
     def get_repo_status(connection, repo_name):
@@ -72,7 +93,9 @@ class RHUIManagerCLI(object):
         (internally used) method to get the status of the given repository
         '''
         Expect.enter(connection, "rhui-manager status")
-        status = Expect.match(connection, re.compile(".*" + Util.esc_parentheses(repo_name) + "[^A-Z]*([A-Za-z]*).*", re.DOTALL))[0]
+        status = Expect.match(connection,
+                              re.compile(".*" + Util.esc_parentheses(repo_name) +
+                                         "[^A-Z]*([A-Za-z]*).*", re.DOTALL))[0]
         return status
 
     @staticmethod
@@ -80,7 +103,9 @@ class RHUIManagerCLI(object):
         '''
         sync a repo
         '''
-        Expect.ping_pong(connection, "rhui-manager repo sync --repo_id " + repo_id, "successfully scheduled for the next available timeslot")
+        Expect.ping_pong(connection,
+                         "rhui-manager repo sync --repo_id " + repo_id,
+                         "successfully scheduled for the next available timeslot")
         repo_status = RHUIManagerCLI.get_repo_status(connection, repo_name)
         while repo_status in ["Never", "Running", "Unknown"]:
             time.sleep(10)
@@ -92,7 +117,9 @@ class RHUIManagerCLI(object):
         '''
         check if information about the given repo can be displayed
         '''
-        Expect.ping_pong(connection, "rhui-manager repo info --repo_id " + repo_id, "Name: *" + Util.esc_parentheses(repo_name))
+        Expect.ping_pong(connection,
+                         "rhui-manager repo info --repo_id " + repo_id,
+                         "Name: *" + Util.esc_parentheses(repo_name))
 
     @staticmethod
     def packages_list(connection, repo_id, package):
@@ -106,7 +133,10 @@ class RHUIManagerCLI(object):
         '''
         upload a package to the custom repo
         '''
-        Expect.ping_pong(connection, "rhui-manager packages upload --repo_id " + repo_id + " --packages " + package, package + " successfully uploaded")
+        Expect.ping_pong(connection,
+                         "rhui-manager packages upload " +
+                         "--repo_id %s --packages %s" % (repo_id, package),
+                         package + " successfully uploaded")
 
     @staticmethod
     def repo_labels(connection, repo_label):
@@ -116,18 +146,29 @@ class RHUIManagerCLI(object):
         Expect.ping_pong(connection, "rhui-manager client labels", repo_label)
 
     @staticmethod
-    def client_cert(connection, repo_labels, name, days, dir):
+    def client_cert(connection, repo_labels, name, days, directory):
         '''
         generate an entitlement certificate
         '''
-        Expect.ping_pong(connection, "rhui-manager client cert --repo_label " + ",".join(repo_labels) + " --name " + name + " --days " + str(days) + " --dir " + dir, "Entitlement certificate created at " + dir + "/" + name + ".crt")
+        Expect.ping_pong(connection,
+                         "rhui-manager client cert --repo_label " + ",".join(repo_labels) + " " +
+                         "--name " + name + " --days " + str(days) + " --dir " + directory,
+                         "Entitlement certificate created at %s/%s.crt" % (directory, name))
 
     @staticmethod
-    def client_rpm(connection, private_key, entitlement_cert, rpm_version, rpm_name, dir, unprotected_repos=[]):
+    def client_rpm(connection, certdata, rpmdata, directory, unprotected_repos=""):
         '''
         generate a client configuration RPM
         '''
-        Expect.ping_pong(connection, "rhui-manager client rpm --private_key " + private_key + " --entitlement_cert " + entitlement_cert + " --rpm_version " + rpm_version + " --rpm_name " + rpm_name + " --dir " + dir + "%s" %(" --unprotected_repos " + ",".join(unprotected_repos) if len(unprotected_repos) > 0 else ""), "RPMs can be found at " + dir)
+        cmd = "rhui-manager client rpm " + \
+              "--private_key %s --entitlement_cert %s " % (certdata[0], certdata[1]) + \
+              "--rpm_version %s --rpm_name %s " % (rpmdata[0], rpmdata[1]) + \
+              "--dir %s" % (directory)
+        if unprotected_repos:
+            cmd += " --unprotected_repos " + ",".join(unprotected_repos)
+        Expect.ping_pong(connection,
+                         cmd,
+                         "RPMs can be found at " + directory)
 
     @staticmethod
     def subscriptions_list(connection, what="registered", poolonly=False):


### PR DESCRIPTION
These changes improve the code so it conforms to common Python coding practices. The code should also be easier to read and maintain now.

The only complaints that pylint has are:

- Unnecessary parens after 'print' keyword - expected with code that's supposed to work on Python 2 and 3
- Too many public methods - expected with a class which is actually a large test case

Tested everywhere, as always; no breakage occurred.

PS. Also removed test_03_remove_existing_entitlement_certificates, which was a leftover test from the days when the other test cases didn't clean up after themselves.