### PR TITLE
make pylint happy with rhui3-automation

### DIFF
--- a/tests/rhui3_tests_lib/rhuimanager_client.py
+++ b/tests/rhui3_tests_lib/rhuimanager_client.py
@@ -1,6 +1,7 @@
 """ RHUIManager Client functions """
 
 from stitches.expect import Expect
+
 from rhui3_tests_lib.rhuimanager import RHUIManager
 
 
@@ -9,7 +10,7 @@ class RHUIManagerClient(object):
     Represents -= Client Entitlement Management =- RHUI screen
     '''
     @staticmethod
-    def generate_ent_cert(connection, repolist, certname, dirname, validity_days="", cert_pw=None):
+    def generate_ent_cert(connection, repolist, certname, dirname, validity_days=""):
         '''
         generate an entitlement certificate
         '''
@@ -26,7 +27,8 @@ class RHUIManagerClient(object):
         RHUIManager.quit(connection)
 
     @staticmethod
-    def create_conf_rpm(connection, dirname, certpath, certkey, rpmname, rpmversion="", unprotected_repos=None):
+    def create_conf_rpm(connection, dirname, certpath, certkey, rpmname, rpmversion="",
+                        unprotected_repos=None):
         '''
         create a client configuration RPM from an entitlement certificate
         '''
@@ -40,7 +42,8 @@ class RHUIManagerClient(object):
         Expect.enter(connection, rpmversion)
         Expect.expect(connection, "Full path to the entitlement certificate.*:")
         Expect.enter(connection, certpath)
-        Expect.expect(connection, "Full path to the private key for the above entitlement certificate:")
+        Expect.expect(connection,
+                      "Full path to the private key for the above entitlement certificate:")
         Expect.enter(connection, certkey)
         if unprotected_repos:
             RHUIManager.select(connection, unprotected_repos)

--- a/tests/rhui3_tests_lib/util.py
+++ b/tests/rhui3_tests_lib/util.py
@@ -1,11 +1,10 @@
 """ Utility functions """
 
-
 import os
-import tempfile
-import time
 import random
 import string
+import tempfile
+import time
 import yaml
 
 from stitches.expect import Expect, ExpectFailed
@@ -26,7 +25,13 @@ class Util(object):
         return res
 
     @staticmethod
-    def generate_gpg_key(connection, keytype="DSA", keysize="1024", keyvalid="0", realname="Key Owner", email="kowner@example.com", comment="comment"):
+    def generate_gpg_key(connection,
+                         keytype="DSA",
+                         keysize="1024",
+                         keyvalid="0",
+                         realname="Key Owner",
+                         email="kowner@example.com",
+                         comment="comment"):
         '''
         Generate GPG keypair
 
@@ -49,7 +54,8 @@ class Util(object):
 
         Expect.enter(connection, "gpg --gen-key --no-random-seed-file --batch /tmp/gpgkey")
         for _ in range(1, 200):
-            Expect.enter(connection, ''.join(random.choice(string.ascii_lowercase) for x in range(200)))
+            Expect.enter(connection,
+                         ''.join(random.choice(string.ascii_lowercase) for x in range(200)))
             time.sleep(1)
             try:
                 Expect.expect(connection, "gpg: done")
@@ -60,7 +66,7 @@ class Util(object):
     @staticmethod
     def remove_amazon_rhui_conf_rpm(connection):
         '''
-        Remove Amazon RHUI configuration rpm from instance (which owns /etc/yum/pluginconf.d/rhui-lb.conf file)
+        Remove Amazon RHUI config rpm (owning /etc/yum/pluginconf.d/rhui-lb.conf) from instance
         '''
         Expect.expect_retval(connection, "if [ -f /etc/yum/pluginconf.d/rhui-lb.conf ]; " +
                              "then rpm -e `rpm -qf --queryformat '%{NAME}\n' " +
@@ -82,7 +88,7 @@ class Util(object):
         tfile = tempfile.NamedTemporaryFile(delete=False)
         tfile.close()
         rhua_connection.sftp.get(pkgpath, tfile.name)
-        file_extension=os.path.splitext(pkgpath)[1]
+        file_extension = os.path.splitext(pkgpath)[1]
         if file_extension == '.rpm':
             connection.sftp.put(tfile.name, tfile.name + file_extension)
             os.unlink(tfile.name)
@@ -115,7 +121,9 @@ class Util(object):
         '''
         if rpmpath:
             rpmnvr = os.popen("basename " + rpmpath).read()[:-1]
-            rpmname = os.popen("rpm -qp --queryformat '%{NAME}\n' " + rpmpath + " 2>/dev/null").read()[:-1]
+            rpmname = os.popen("rpm -qp --queryformat '%{NAME}\n' " +
+                               rpmpath +
+                               " 2>/dev/null").read()[:-1]
             return (rpmnvr, rpmname)
         else:
             return (None, None)
@@ -147,7 +155,7 @@ class Util(object):
         helper method to escape parentheses so they can be safely used inside
         regular expressions in Expect methods
         '''
-        return name.replace("(", "\(").replace(")", "\)")
+        return name.replace("(", r"\(").replace(")", r"\)")
 
     @staticmethod
     def format_repo(name, version, kind=""):

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -20,9 +20,11 @@ DATAFILES = [('share/rhui3_tests_lib/rhui3_tests', glob('rhui3_tests/*'))]
 
 setup(name='rhui3_tests_lib',
       version='1.0',
-      description='RHUI3 Testing Library',
-      author='Martin Minar',
-      author_email='mminar@redhat.com',
+      description='RHUI 3 Testing Library',
+      long_description='libraries to control the rhui-manager UI and facilitate other useful tasks',
+      author='RHUI QE Team',
+      author_email='noreply@redhat.com',
+      platforms='Linux',
       url='https://github.com/RedHatQE/rhui3-automation',
       license="GPLv3+",
       packages=[

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,43 +1,43 @@
 #!/usr/bin/env python
+'''
+   Setup file for the rhui3-automation test suite.
+   Use "pip install ." in this directory to install the test suite and its dependencies.
+'''
 
-from setuptools import setup
-import glob
-import os
+from glob import glob
 import sys
 
-requirements=['nose>=1.3.0', 'requests', 'stitches>=0.12']
+from setuptools import setup
+
+REQUIREMENTS = ['nose>=1.3.0', 'stitches>=0.12']
 
 # Workaround for https://github.com/paramiko/paramiko/issues/1123
-python_version=sys.version_info[0] + sys.version_info[1] / 10.0
-if python_version <= 2.6:
-    requirements.append('paramiko==2.3.1')
+PYTHON_VERSION = sys.version_info[0] + sys.version_info[1] / 10.0
+if PYTHON_VERSION <= 2.6:
+    REQUIREMENTS.append('paramiko==2.3.1')
 
-datafiles = []
-for topdir in ['rhui3_tests']:
-    for dirname, dirnames, filenames in os.walk(topdir):
-        datafiles.append(('share/rhui3_tests_lib/' + dirname, map(lambda x: dirname + "/" + x, filenames)))
+DATAFILES = [('share/rhui3_tests_lib/rhui3_tests', glob('rhui3_tests/*'))]
 
 setup(name='rhui3_tests_lib',
-    version='1.0',
-    description='RHUI3 Testing Library',
-    author='Martin Minar',
-    author_email='mminar@redhat.com',
-    url='https://github.com/RedHatQE/rhui3-automation',
-    license="GPLv3+",
-    packages=[
-        'rhui3_tests_lib'
-        ],
-    data_files=datafiles,
-    install_requires=requirements,
-    zip_safe=False,
-    classifiers=[
-            'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-            'Programming Language :: Python',
-            'Topic :: Software Development :: Libraries :: Python Modules',
-            'Operating System :: POSIX',
-            'Intended Audience :: Developers',
-            'Development Status :: 5 - Production/Stable'
-    ],
-    scripts=glob.glob('scripts/*.py') + glob.glob('scripts/*.sh')
-)
-
+      version='1.0',
+      description='RHUI3 Testing Library',
+      author='Martin Minar',
+      author_email='mminar@redhat.com',
+      url='https://github.com/RedHatQE/rhui3-automation',
+      license="GPLv3+",
+      packages=[
+          'rhui3_tests_lib'
+      ],
+      data_files=DATAFILES,
+      install_requires=REQUIREMENTS,
+      zip_safe=False,
+      classifiers=[
+          'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+          'Programming Language :: Python',
+          'Topic :: Software Development :: Libraries :: Python Modules',
+          'Operating System :: POSIX',
+          'Intended Audience :: Developers',
+          'Development Status :: 5 - Production/Stable'
+      ],
+      scripts=glob('scripts/*.py') + glob('scripts/*.sh')
+     )


### PR DESCRIPTION
This commit changes the client tests, the atomic clients tests & libraries, as well as the rest of the rhuimanager libraries so that pylint has no objections other than those that seem inevitable (using parens with print to ensure compatibility across versions) or would be impractical to avoid (too many arguments for those tasks in rhui-manager that just take many answers). As always, everything still works on RHEL 6 & 7 with distribution Python versions and with Python 3.6.

Just to summarize the changes:

- no long lines
- proper names of constants
- proper imports (no wildcard, no multiple items, correct order)
- proper whitespace use (alignment, padding)
- no redefined builtins
- no insanely long function/method names
- no anomalous backslashes
- no wild lambdas