### PR TITLE
write RHEL-5 client data to hosts.cfg when requested

### DIFF
--- a/RHEL5mapping.json
+++ b/RHEL5mapping.json
@@ -1,0 +1,47 @@
+{
+    "us-east-1": {
+        "AMI": "ami-fe94dd96"
+    }, 
+    "us-west-1": {
+        "AMI": "ami-c4aeb581"
+    }, 
+    "ap-northeast-2": {
+        "AMI": ""
+    }, 
+    "ap-northeast-1": {
+        "AMI": "ami-afc522af"
+    }, 
+    "sa-east-1": {
+        "AMI": "ami-55249b48"
+    }, 
+    "ap-southeast-1": {
+        "AMI": "ami-1edaef4c"
+    }, 
+    "ca-central-1": {
+        "AMI": ""
+    }, 
+    "ap-southeast-2": {
+        "AMI": "ami-739fe849"
+    }, 
+    "us-west-2": {
+        "AMI": "ami-0da7823d"
+    }, 
+    "us-east-2": {
+        "AMI": ""
+    }, 
+    "ap-south-1": {
+        "AMI": ""
+    }, 
+    "eu-central-1": {
+        "AMI": "ami-4a8cbf57"
+    }, 
+    "eu-west-1": {
+        "AMI": "ami-637bf014"
+    }, 
+    "eu-west-2": {
+        "AMI": ""
+    }, 
+    "eu-west-3": {
+        "AMI": ""
+    }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,6 +57,16 @@ Default configuration:
   
 \* ATOMIC CLI machines can be run only with RHEL7 RHUI setup
 
+Note that RHEL-5 AMIs are not available in all regions;
+see the [RHEL 5 mapping file](RHEL5mapping.json).
+Attempts to launch a RHEL-5 client in a region that does not have a RHEL-5 AMI will fail.
+
+Moreover, with Ansible 2.4 and newer, it is no longer possible to manage machines with Python older
+than 2.6. RHEL 5 has Python 2.4. To avoid failures, the hosts configuration file will be created
+with the RHEL-5 client hostname and other data commented out so that it is all visible to you but
+ignored by `ansible-playbook`. Other than that, you are free to use the launched RHEL-5 client any
+way you want, just be sure to log in as root directly.
+
 Mutually exclusive options: 
 
   * **--nfs** - if specified, nfs filesystem with separate machine and NFS volume (100 GB) attached to this machine

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -173,6 +173,9 @@ try:
     with open("RHEL6mapping.json") as b:
         rhel6mapping = json.load(b)
 
+    with open("RHEL5mapping.json") as b:
+        rhel5mapping = json.load(b)
+
     with open("ATOMICmapping.json") as c:
         atomicmapping = json.load(c)
 
@@ -183,11 +186,13 @@ except Exception as e:
 json_dict['Mappings'] = \
   {u'RHEL7': {},
    u'RHEL6': {},
+   u'RHEL5': {},
    u'ATOMIC': {}
   }
   
 json_dict['Mappings']['RHEL7'] = rhel7mapping
 json_dict['Mappings']['RHEL6'] = rhel6mapping
+json_dict['Mappings']['RHEL5'] = rhel5mapping
 json_dict['Mappings']['ATOMIC'] = atomicmapping
 
 json_dict['Parameters'] = \
@@ -639,9 +644,18 @@ try:
             f.write('\n[CLI]\n')
             for instance in instances_detail:
                 if instance["role"] == "CLI":
+                    # RHEL 5 can't be set up using ansible 2.4+
+                    # write the data anyway so the user can see it, but comment it out
+                    if instance["OS"] == "RHEL5":
+                        f.write('#')
                     f.write(str(instance['public_hostname']))
                     f.write(' ')
-                    f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
+                    # only RHEL >= 6 has ec2-user, RHEL 5 has just root
+                    if instance["OS"] == "RHEL5":
+                        f.write('ansible_ssh_user=root ')
+                    else:
+                        f.write('ansible_ssh_user=ec2-user ansible_become=True ')
+                    f.write('ansible_ssh_private_key_file=')
                     f.write(ssh_key)
                     f.write('\n')
         # atomic_cli

--- a/scripts/get_amis_list.py
+++ b/scripts/get_amis_list.py
@@ -22,6 +22,8 @@ if args.rhel.startswith("RHEL-7"):
     mapping = "RHEL7mapping.json"
 elif args.rhel.startswith("RHEL-6"):
     mapping = "RHEL6mapping.json"
+elif args.rhel.startswith("RHEL-5"):
+    mapping = "RHEL5mapping.json"
 elif args.rhel.startswith("RHEL-Atomic"):
     mapping = "ATOMICmapping.json"
 else:


### PR DESCRIPTION
The stack creation script recognizes the --cli5 option but doesn't really launch a RHEL-5 client as there's no AMI info about RHEL 5. I'd like to add a mapping file with AMI IDs for the regions that have RHEL 5; I've created the mapping file using RHEL-5.11_GA-20150209-x86_64-1-Hourly2-GP2. Also, small changes are needed to the code to actually handle the creation of a RHEL 5 machine.

Some observations:

- RHEL 5 doesn't have ec2-user; one is supposed to log in as root, so the generated hosts cfg file reflects that.
- Unfortunately, if I try creating a RHUI environment with a RHEL-5 client, Ansible fails to set up the client:

`File \"/tmp/ansible_LvtXGp/ansible_module_setup.py\", line 7\r\n    from __future__ import absolute_import, division, print_function\r\nSyntaxError: future feature absolute_import is not defined\r\n"`

This is because modern versions of Ansible do things on the remote hosts that expect the hosts to have a modern Python version. So I suggest we write the information about the RHEL-5 client into the hosts cfg file but comment it out so it doesn't break the setup of the RHUI environment. One can then take the hostname from the cfg file and play with the client manually.