### PR TITLE
complete the Atomic repo test coverage

### DIFF
--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -1,8 +1,4 @@
 '''Atomic client tests (RHEL 7+ only)'''
-#
-# some tests are commented out because the Atomic Trees repo won't sync reliably
-# see RHBZ#1427190
-#
 
 from os.path import basename
 

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -11,6 +11,8 @@ yum_repo2:
 atomic_repo:
     name: "Red Hat Enterprise Linux Atomic Host (Trees) from RHUI"
     kind: "Atomic"
+    remote: "rhui-rhel-atomic-host-rhui-ostree"
+    ref: "rhel-atomic-host/7/x86_64/standard"
 CLI_repo1:
     name: "Red Hat Enterprise Linux Atomic Host (Debug RPMs) from RHUI"
     id: "rhel-atomic-host-rhui-debug-rpms-x86_64"


### PR DESCRIPTION
I've been looking into the issue with the Atomic repo failing to sync (and an Atomic client failing to pull from it) and I have the explanation as well as the solution now.

When the sync task is done, it's followed by a publish task which is supposed to make all the files available by Apache. Strangely, when the publish task runs for the first time, it completes immediately and doesn't do its job. See the following list of Pulp tasks:

```
Operations:  sync
Resources:   rhel-atomic-host-rhui-ostree--rhel-atomic-host-7-x86_64-standard
             (repository)
State:       Successful
Start Time:  2018-07-31T13:47:19Z
Finish Time: 2018-07-31T13:58:02Z
Task Id:     2f196d2c-1c48-401b-a511-d2f7e59400a1

Operations:  publish
Resources:   rhel-atomic-host-rhui-ostree--rhel-atomic-host-7-x86_64-standard
             (repository)
State:       Successful
Start Time:  2018-07-31T13:58:03Z
Finish Time: 2018-07-31T13:58:03Z
Task Id:     ac2ba531-7537-4085-a0d3-304cc829b94c
```

When I sync the repo again (which itself then takes just a few seconds), the following publish task runs for real and does what it's supposed to do:

```
Operations:  sync
Resources:   rhel-atomic-host-rhui-ostree--rhel-atomic-host-7-x86_64-standard
             (repository)
State:       Successful
Start Time:  2018-07-31T13:58:21Z
Finish Time: 2018-07-31T13:58:25Z
Task Id:     6ba15800-fc21-46dd-800b-a4af2308f649

Operations:  publish
Resources:   rhel-atomic-host-rhui-ostree--rhel-atomic-host-7-x86_64-standard
             (repository)
State:       Successful
Start Time:  2018-07-31T13:58:25Z
Finish Time: 2018-07-31T14:03:53Z
Task Id:     b4e3e630-926f-4549-b374-f5a2351b026d
```

Note that `ostree pull` won't work until the publish task is complete.

The solution is to sync the repo twice and wait for the (second) publish task to finish, which is what the test does now.

```
*** Running test_atomic_client.py: *** 
do initial rhui-manager run ... ok
add a CDS ... ok
add an HAProxy Load-balancer ... ok
upload the Atomic cert ... ok
add the RHEL Atomic Host (Trees) from RHUI repo ... ok
start syncing the repo ... ok
generate an entitlement certificate for the repo ... ok
create an Atomic client configuration package ... ok
wait until the repo is synced (takes a while) ... ok
install the Atomic client configuration package on the Atomic host ... ok
sync the repo again (workaround for RHBZ#1427190) ... ok
wait until the repo publish task is complete (takes extra time) ... ok
pull Atomic content ... ok
check if the repo data was fetched on the client ... ok
remove the repo, uninstall CDS and HAProxy, delete the configuration package and RH cert ... ok
*** Finished running test_atomic_client.py. *** 

----------------------------------------------------------------------
Ran 15 tests in 1473.225s

OK
```
A second run would take about 800 seconds.