### PR TITLE
install tested_repos.py to a special dir, suggest using the installed…

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -128,5 +128,5 @@
   tags: tests
 
 - name: run tests suite
-  shell: nosetests -vs /tmp/rhui3-tests/tests &>>/tmp/rhui3test.log
+  shell: nosetests -vs /usr/share/rhui3_tests_lib/rhui3_tests &>>/tmp/rhui3test.log
   tags: run_tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,17 +65,17 @@ Provide any other optional variables described in the RHUI deployment Readme as 
 
 Note that it can take a few hours for all the test cases to run. If you only want to install the test machine, add `--skip-tags run_tests` on the command line.
 
-The framework will be installed in the `/tmp/rhui3-tests` directory on the TEST machine. The output of the tests will be stored in `/tmp/rhui3test.log` on the TEST machine.
+The test cases will be installed in the `/usr/share/rhui3_tests_lib/rhui3_tests/` directory and the libraries in the `/usr/lib/python*/site-packages/rhui3_tests_lib/` directory on the TEST machine. The output of the tests will be stored in `/tmp/rhui3test.log` on the TEST machine.
 
 If you now want to run the whole test suite, or if you want to run it again, you have two options. Either use _Ansible_ again as follows:
 
 `ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --tags run_tests`
 
-Or log in to the TEST machine, become root, enter the `/tmp/rhui3-tests/` directory, and use _nose_ as follows:
+Or log in to the TEST machine, become root, and use _nose_ as follows:
 
-`nosetests -vs tests/rhui3_tests`
+`nosetests -vs /usr/share/rhui3_tests_lib/rhui3-tests`
 
-To run only a single test case, or a subset of the available test cases, specify the test case(s) as the corresponding `test_XYZ.py` file name(s) on the `nosetests -vs` command line instead of `tests/rhui3_tests`, which is the directory containing all the test cases. For example:
+To run only a single test case, or a subset of the available test cases, specify the test case(s) as the corresponding `test_XYZ.py` file name(s) on the `nosetests -vs` command line instead of the directory containing all the test cases. For example:
 
-`nosetests -vs tests/rhui3_tests/test_client_management.py`
+`nosetests -vs /usr/share/rhui3_tests_lib/rhui3-tests/test_client_management.py`
 

--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -32,7 +32,7 @@ class TestClient(object):
         if self.rhua_os_version < 7:
             raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.rhua_os_version))
 
-        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+        with open('/usr/share/rhui3_tests_lib/config/tested_repos.yaml', 'r') as configfile:
             doc = yaml.load(configfile)
 
         self.atomic_repo_name = doc['atomic_repo']['name']

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -35,7 +35,7 @@ class TestClient(object):
     def __init__(self):
         self.rhua_os_version = Util.get_rhua_version(CONNECTION)["major"]
 
-        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+        with open('/usr/share/rhui3_tests_lib/config/tested_repos.yaml', 'r') as configfile:
             doc = yaml.load(configfile)
 
         self.yum_repo1_name = doc['yum_repo1']['name']

--- a/tests/rhui3_tests/test_cmdline.py
+++ b/tests/rhui3_tests/test_cmdline.py
@@ -31,7 +31,7 @@ class TestCLI(object):
     '''
 
     def __init__(self):
-        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+        with open('/usr/share/rhui3_tests_lib/config/tested_repos.yaml', 'r') as configfile:
             doc = yaml.load(configfile)
 
         self.yum_repo_name_1 = doc['CLI_repo1']['name']

--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -23,7 +23,7 @@ class TestRepo(object):
     '''
 
     def __init__(self):
-        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+        with open('/usr/share/rhui3_tests_lib/config/tested_repos.yaml', 'r') as configfile:
             doc = yaml.load(configfile)
 
         self.yum_repo_name = doc['yum_repo1']['name']

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -23,7 +23,7 @@ class TestSubscription(object):
     '''
 
     def __init__(self):
-        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+        with open('/usr/share/rhui3_tests_lib/config/tested_repos.yaml', 'r') as configfile:
             doc = yaml.load(configfile)
         self.subscription_name_1 = doc['subscription1']['name']
 

--- a/tests/rhui3_tests/test_sync_management.py
+++ b/tests/rhui3_tests/test_sync_management.py
@@ -23,7 +23,7 @@ class TestSync(object):
     '''
 
     def __init__(self):
-        with open('/tmp/rhui3-tests/tests/rhui3_tests/tested_repos.yaml', 'r') as configfile:
+        with open('/usr/share/rhui3_tests_lib/config/tested_repos.yaml', 'r') as configfile:
             doc = yaml.load(configfile)
 
         self.yum_repo_name = doc['yum_repo1']['name']

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -16,7 +16,8 @@ PYTHON_VERSION = sys.version_info[0] + sys.version_info[1] / 10.0
 if PYTHON_VERSION <= 2.6:
     REQUIREMENTS.append('paramiko==2.3.1')
 
-DATAFILES = [('share/rhui3_tests_lib/rhui3_tests', glob('rhui3_tests/*'))]
+DATAFILES = [('share/rhui3_tests_lib/rhui3_tests', glob('rhui3_tests/test_*')),
+             ('share/rhui3_tests_lib/config', ['rhui3_tests/tested_repos.yaml'])]
 
 setup(name='rhui3_tests_lib',
       version='1.0',


### PR DESCRIPTION
… files

The setup script that we have installs the framework as follows:

- libraries are in `/usr/lib/python*/site-packages/rhui3_tests_lib`
- test cases and the `tested_repos.py` file are in `/usr/share/rhui3_tests_lib/rhui3_tests`

Yet the `Readme` file suggests running the tests from `/tmp/rhui3-tests`. It would be better to suggest using the installed files as then it all looks official, and also because the files in the temporary directory get deleted by `tmpwatch` if you don't use them for a long time. (It has happened to me before.)

In addition, it makes more sense to me to install the `tested_repos.py` file to a directory dedicated to configuration files, not among the test cases themselves. At the same time, the test cases that load this file should load the installed file, not the one from /tmp, which as I said can disappear over time.