### PR TITLE
improve initial_run and run it only when needed

### DIFF
--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -109,7 +109,6 @@ class TestClient(object):
         '''
            create an Atomic client configuration package
         '''
-        RHUIManager.initial_run(CONNECTION)
         RHUIManagerClient.create_atomic_conf_pkg(CONNECTION,
                                                  "/root",
                                                  "test_atomic_pkg",

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -131,7 +131,6 @@ class TestClient(object):
         '''
            create a client configuration RPM from an entitlement certificate
         '''
-        RHUIManager.initial_run(CONNECTION)
         RHUIManagerClient.create_conf_rpm(CONNECTION,
                                           "/root",
                                           "/root/test_ent_cli.crt",
@@ -179,7 +178,6 @@ class TestClient(object):
         '''
            check if RH repos were synced to install rpm
         '''
-        RHUIManager.initial_run(CONNECTION)
         if self.rhua_os_version < 7:
             RHUIManagerSync.wait_till_repo_synced(CONNECTION,
                                                   [Util.format_repo(self.yum_repo1_name,
@@ -208,7 +206,6 @@ class TestClient(object):
         '''
            create a docker client configuration RPM
         '''
-        RHUIManager.initial_run(CONNECTION)
         RHUIManagerClient.create_docker_conf_rpm(CONNECTION, "/root", "test_docker_cli_rpm", "4.0")
         Expect.expect_retval(CONNECTION,
                              "test -f /root/test_docker_cli_rpm-4.0/build/RPMS/noarch/" +
@@ -291,7 +288,6 @@ class TestClient(object):
         '''
            remove repos, certs, cli rpms; remove rpms from cli, uninstall cds, hap
         '''
-        RHUIManager.initial_run(CONNECTION)
         RHUIManagerRepo.delete_all_repos(CONNECTION)
         nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
         RHUIManagerInstance.delete(CONNECTION, "loadbalancers", ["hap01.example.com"])

--- a/tests/rhui3_tests_lib/rhuimanager.py
+++ b/tests/rhui3_tests_lib/rhuimanager.py
@@ -171,7 +171,7 @@ class RHUIManager(object):
     @staticmethod
     def initial_run(connection, username="admin", password="admin"):
         '''
-        Do rhui-manager initial run
+        Run rhui-manager and make sure we're logged in, then quit it.
         '''
         Expect.enter(connection, "rhui-manager")
         state = Expect.expect_list(connection,
@@ -196,11 +196,7 @@ class RHUIManager(object):
                 Expect.expect(connection, "RHUI Password:")
                 Expect.enter(connection, initial_password)
                 Expect.expect(connection, r"rhui \(home\) =>")
-            else:
-                pass
-        else:
-            # initial step was already performed by someone
-            pass
+        Expect.enter(connection, "q")
 
     @staticmethod
     def change_user_password(connection, password='admin'):


### PR DESCRIPTION
For some reason, `initial_run()` was executed more than once in some test cases; this is unnecessary as the purpose of this method is to make sure we're logged in, not to re-launch `rhui-manager`, which is the responsibility of the individual methods that deal with the tool, ie. e.g. screen(). Also, the method didn't close `rhui-manager`, so the very next method called in a given test case would actually "talk" with the `rhui-manager` prompt, not BASH; I guess this part was a relic from when everything was done in a single `rhui-manager` session in the past. It wasn't really an issue as the methods called afterwards would proceed to the right screen anyway, but it's better to close `rhui-manager` in `initial_run`.

No breakage was found after making these changes.