### PR TITLE
test coverage for Display Detailed Information

### DIFF
--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -29,6 +29,7 @@ class TestRepo(object):
         self.yum_repo_name = doc['yum_repo1']['name']
         self.yum_repo_version = doc['yum_repo1']['version']
         self.yum_repo_kind = doc['yum_repo1']['kind']
+        self.yum_repo_path = doc['yum_repo1']['path']
         self.docker_container_name = doc['docker_container1']['name']
         self.docker_container_displayname = doc['docker_container1']['displayname']
 
@@ -82,7 +83,7 @@ class TestRepo(object):
                                 ['custom-i386-i386', 'custom-i386-x86_64', 'custom-x86_64-x86_64'])
 
     @staticmethod
-    def test_05_repo_id_uniqness():
+    def test_05_repo_id_uniqueness():
         '''Check that repo id is unique'''
         RHUIManagerRepo.add_custom_repo(CONNECTION,
                                         "custom-i386-x86_64",
@@ -99,14 +100,14 @@ class TestRepo(object):
                                        "/tmp/extra_rhui_files/rhui-rpm-upload-test-1-1.noarch.rpm")
 
     @staticmethod
-    def test_06_01_upload_several_rpms():
+    def test_07_upload_several_rpms():
         '''Upload several rpms to the custom repo from a directory'''
         RHUIManagerRepo.upload_content(CONNECTION,
                                        ["custom-i386-x86_64"],
                                        "/tmp/extra_rhui_files/")
 
     @staticmethod
-    def test_06_02_check_for_package():
+    def test_08_check_for_package():
         '''Check the packages list'''
         nose.tools.assert_equal(RHUIManagerRepo.check_for_package(CONNECTION,
                                                                   "custom-i386-x86_64",
@@ -127,7 +128,26 @@ class TestRepo(object):
                                 [])
 
     @staticmethod
-    def test_07_remove_3_custom_repos():
+    def test_09_display_custom_repos():
+        '''Check detailed information on the custom repos'''
+        RHUIManagerRepo.check_detailed_information(CONNECTION,
+                                                   ["custom-i386-x86_64", "custom/i386/x86_64"],
+                                                   [True, True],
+                                                   [True, None, True],
+                                                   2)
+        RHUIManagerRepo.check_detailed_information(CONNECTION,
+                                                   ["custom-x86_64-x86_64", "custom/x86_64/x86_64"],
+                                                   [True, False],
+                                                   [True, None, True],
+                                                   0)
+        RHUIManagerRepo.check_detailed_information(CONNECTION,
+                                                   ["custom-i386-i386", "custom/i386/i386"],
+                                                   [True, True],
+                                                   [False],
+                                                   0)
+
+    @staticmethod
+    def test_10_remove_3_custom_repos():
         '''Remove 3 custom repos'''
         RHUIManagerRepo.delete_repo(CONNECTION,
                                     ["custom-i386-x86_64",
@@ -135,42 +155,52 @@ class TestRepo(object):
                                      "custom-i386-i386"])
         nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
 
-    def test_08_add_rh_repo_by_repo(self):
+    def test_11_add_rh_repo_by_repo(self):
         '''Add a RH repo by repository'''
         RHUIManagerRepo.add_rh_repo_by_repo(CONNECTION, [Util.format_repo(self.yum_repo_name,
                                                                           self.yum_repo_version,
                                                                           self.yum_repo_kind)])
         nose.tools.assert_not_equal(RHUIManagerRepo.list(CONNECTION), [])
 
-    def test_09_delete_one_repo(self):
+    def test_12_display_rh_repo(self):
+        '''Check detailed information on the RH repo'''
+        RHUIManagerRepo.check_detailed_information(CONNECTION,
+                                                   [Util.format_repo(self.yum_repo_name,
+                                                                     self.yum_repo_version),
+                                                    self.yum_repo_path],
+                                                   [False],
+                                                   [True, None, True],
+                                                   0)
+
+    def test_13_delete_one_repo(self):
         '''Remove a RH repo'''
         RHUIManagerRepo.delete_repo(CONNECTION, [self.yum_repo_name + ".*"])
         nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
 
-    def test_10_add_rh_repo_by_product(self):
+    def test_14_add_rh_repo_by_product(self):
         '''Add a RH repo by product'''
         RHUIManagerRepo.add_rh_repo_by_product(CONNECTION, [self.yum_repo_name])
         #nose.tools.assert_not_equal(RHUIManagerRepo.list(CONNECTION), [])
 
     @staticmethod
-    def test_11_delete_repo():
+    def test_15_delete_repo():
         '''Remove a RH repo'''
         RHUIManagerRepo.delete_all_repos(CONNECTION)
         nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
 
     @staticmethod
-    def test_12_add_all_rh_repos():
+    def test_16_add_all_rh_repos():
         '''Add all RH repos'''
         RHUIManagerRepo.add_rh_repo_all(CONNECTION)
         #nose.tools.assert_not_equal(RHUIManagerRepo.list(CONNECTION), [])
 
     @staticmethod
-    def test_13_delete_all_repos():
+    def test_17_delete_all_repos():
         '''Delete all repositories from RHUI'''
         RHUIManagerRepo.delete_all_repos(CONNECTION)
         nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
 
-    def test_14_add_docker_container(self):
+    def test_18_add_docker_container(self):
         '''Add a RH docker container'''
         RHUIManagerRepo.add_docker_container(CONNECTION,
                                              self.docker_container_name,
@@ -178,14 +208,24 @@ class TestRepo(object):
                                              self.docker_container_displayname)
         nose.tools.assert_not_equal(RHUIManagerRepo.list(CONNECTION), [])
 
+    def test_19_display_docker_cont(self):
+        '''Check detailed information on the docker container'''
+        RHUIManagerRepo.check_detailed_information(CONNECTION,
+                                                   [self.docker_container_displayname,
+                                                    "https://cds.example.com/pulp/docker/%s/" % \
+                                                    self.docker_container_name.replace("/", "_")],
+                                                   [False],
+                                                   [True, None, True],
+                                                   0)
+
     @staticmethod
-    def test_15_delete_docker_container():
+    def test_20_delete_docker_container():
         '''Delete a docker container'''
         RHUIManagerRepo.delete_all_repos(CONNECTION)
         nose.tools.assert_equal(RHUIManagerRepo.list(CONNECTION), [])
 
     @staticmethod
-    def test_16_delete_rh_cert():
+    def test_99_delete_rh_cert():
         '''Delete the RH cert'''
         RHUIManager.remove_rh_certs(CONNECTION)
 


### PR DESCRIPTION
Adding a library method and test cases for _Repository Management_ -> _i   display detailed information on a repository_. The method needs to be called with the properties the checked repo was created with (or described in `tested_repos.py`), and it can examine both custom and Red Hat repos.

Note that if a property doesn't match, you'll see a comparison of all the expected and actual properties. (You need to redirect the `nosetests` output to a file, as usual, since rhui-manager clears the terminal.)

PS. I fixed an incorrectly spelled word ("uniqness") while modifying the test numbers.