### PR TITLE
[WIP] update AMIs to those that fix L1TF

### DIFF
--- a/ATOMICmapping.json
+++ b/ATOMICmapping.json
@@ -1,47 +1,47 @@
 {
     "us-east-1": {
-        "AMI": "ami-0e782571"
+        "AMI": "ami-05af8cb867ed5261c"
     }, 
     "us-west-1": {
-        "AMI": "ami-c755b2a4"
+        "AMI": "ami-0c538e14bbe22162f"
     }, 
     "ap-northeast-2": {
-        "AMI": "ami-dbfd48b5"
+        "AMI": "ami-04cc887d4a5677183"
     }, 
     "ap-northeast-1": {
-        "AMI": "ami-30a7734f"
+        "AMI": "ami-0d4f1004ca9788ace"
     }, 
     "sa-east-1": {
-        "AMI": "ami-83bbe1ef"
+        "AMI": "ami-0ce733729b4d1bccf"
     }, 
     "ap-southeast-1": {
-        "AMI": "ami-f8787b84"
+        "AMI": "ami-0f2d43e4545d9aff2"
     }, 
     "ca-central-1": {
-        "AMI": "ami-e4dd5f80"
+        "AMI": "ami-8a3db0ee"
     }, 
     "ap-southeast-2": {
-        "AMI": "ami-04b56c66"
+        "AMI": "ami-0e8fef8c7d8a2cc49"
     }, 
     "us-west-2": {
-        "AMI": "ami-e9400e91"
+        "AMI": "ami-00bf8af0eb2974552"
     }, 
     "us-east-2": {
-        "AMI": "ami-6e231a0b"
+        "AMI": "ami-00547eb6e5074dfe2"
     }, 
     "ap-south-1": {
-        "AMI": "ami-50dcf63f"
+        "AMI": "ami-08c1597ffba2073df"
     }, 
     "eu-central-1": {
-        "AMI": "ami-76ba869d"
+        "AMI": "ami-0d397506fb87a591c"
     }, 
     "eu-west-1": {
-        "AMI": "ami-7a3f3390"
+        "AMI": "ami-041d2cb2ff6ccaf23"
     }, 
     "eu-west-2": {
-        "AMI": "ami-fb52bc9c"
+        "AMI": "ami-0ac96656aab40c51a"
     }, 
     "eu-west-3": {
-        "AMI": "ami-02f0407f"
+        "AMI": "ami-0820c1744b1e6404f"
     }
 }

--- a/RHEL6mapping.json
+++ b/RHEL6mapping.json
@@ -1,47 +1,47 @@
 {
     "us-east-1": {
-        "AMI": "ami-6d176b12"
+        "AMI": "ami-068badb9d8b027e27"
     }, 
     "us-west-1": {
-        "AMI": "ami-adff1ace"
+        "AMI": "ami-0291d914be8e1d8fb"
     }, 
     "ap-northeast-2": {
-        "AMI": "ami-0ae94364"
+        "AMI": "ami-05b76025ce2cb47ee"
     }, 
     "ap-northeast-1": {
-        "AMI": "ami-fd6dac82"
+        "AMI": "ami-055e3cab13d7ee3d8"
     }, 
     "sa-east-1": {
-        "AMI": "ami-89560ee5"
+        "AMI": "ami-0f728f278aebb9535"
     }, 
     "ap-southeast-1": {
-        "AMI": "ami-4a8eb536"
+        "AMI": "ami-02ae5ed44ec52955c"
     }, 
     "ca-central-1": {
-        "AMI": "ami-9742c1f3"
+        "AMI": "ami-512ba635"
     }, 
     "ap-southeast-2": {
-        "AMI": "ami-c874a9aa"
+        "AMI": "ami-07ec952f21f4de9ab"
     }, 
     "us-west-2": {
-        "AMI": "ami-80296ff8"
+        "AMI": "ami-0db2ed7b1c125df2b"
     }, 
     "us-east-2": {
-        "AMI": "ami-16a99673"
+        "AMI": "ami-0839cf52d34b1324f"
     }, 
     "ap-south-1": {
-        "AMI": "ami-d3e2cbbc"
+        "AMI": "ami-0fa1e412c40bec3e7"
     }, 
     "eu-central-1": {
-        "AMI": "ami-1ce1d7f7"
+        "AMI": "ami-0e2c0f819f8aeb57f"
     }, 
     "eu-west-1": {
-        "AMI": "ami-cccecfb5"
+        "AMI": "ami-091384e6d5405f620"
     }, 
     "eu-west-2": {
-        "AMI": "ami-d7d13eb0"
+        "AMI": "ami-d7b642b0"
     }, 
     "eu-west-3": {
-        "AMI": "ami-8c3a8bf1"
+        "AMI": "ami-026b40dfeb677ed2d"
     }
 }

--- a/RHEL6mapping.json
+++ b/RHEL6mapping.json
@@ -9,7 +9,7 @@
         "AMI": "ami-05b76025ce2cb47ee"
     }, 
     "ap-northeast-1": {
-        "AMI": "ami-055e3cab13d7ee3d8"
+        "AMI": "ami-06abe5f9b405cab2c"
     }, 
     "sa-east-1": {
         "AMI": "ami-0f728f278aebb9535"

--- a/RHEL7mapping.json
+++ b/RHEL7mapping.json
@@ -1,47 +1,47 @@
 {
     "us-east-1": {
-        "AMI": "ami-6871a115"
+        "AMI": "ami-0456c465f72bd0c95"
     }, 
     "us-west-1": {
-        "AMI": "ami-18726478"
+        "AMI": "ami-02574210e91c38419"
     }, 
     "ap-northeast-2": {
-        "AMI": "ami-3eee4150"
+        "AMI": "ami-031161cd3182e012a"
     }, 
     "ap-northeast-1": {
-        "AMI": "ami-6b0d5f0d"
+        "AMI": "ami-0bf9ecb88f5719e17"
     }, 
     "sa-east-1": {
-        "AMI": "ami-b0b7e3dc"
+        "AMI": "ami-0a419d7f7b8b07b64"
     }, 
     "ap-southeast-1": {
-        "AMI": "ami-76144b0a"
+        "AMI": "ami-0f44e46fa59e902b6"
     }, 
     "ca-central-1": {
-        "AMI": "ami-49f0762d"
+        "AMI": "ami-e320ad87"
     }, 
     "ap-southeast-2": {
-        "AMI": "ami-67589505"
+        "AMI": "ami-0066ef2f9c72fad96"
     }, 
     "us-west-2": {
-        "AMI": "ami-28e07e50"
+        "AMI": "ami-0e6bab6682ec471c0"
     }, 
     "us-east-2": {
-        "AMI": "ami-03291866"
+        "AMI": "ami-04268981d7c33264d"
     }, 
     "ap-south-1": {
-        "AMI": "ami-5b673c34"
+        "AMI": "ami-0c6ec6988a8df3acc"
     }, 
     "eu-central-1": {
-        "AMI": "ami-c86c3f23"
+        "AMI": "ami-07d3f0705bebac978"
     }, 
     "eu-west-1": {
-        "AMI": "ami-7c491f05"
+        "AMI": "ami-0c51cd02617947143"
     }, 
     "eu-west-2": {
-        "AMI": "ami-7c1bfd1b"
+        "AMI": "ami-01f010afd559615b9"
     }, 
     "eu-west-3": {
-        "AMI": "ami-5026902d"
+        "AMI": "ami-0a0167e3e2a1d1d9b"
     }
 }

--- a/scripts/get_amis_list.py
+++ b/scripts/get_amis_list.py
@@ -24,7 +24,7 @@ elif args.rhel.startswith("RHEL-6"):
     mapping = "RHEL6mapping.json"
 elif args.rhel.startswith("RHEL-5"):
     mapping = "RHEL5mapping.json"
-elif args.rhel.startswith("RHEL-Atomic"):
+elif args.rhel.startswith("RHEL-Atomic") or args.rhel.startswith("Atomic"):
     mapping = "ATOMICmapping.json"
 else:
     sys.stderr.write("Wrong parameters")


### PR DESCRIPTION
The mapping files were regenerated using these commands:

./scripts/get_amis_list.py --rhel \
RHEL-6.10_HVM-20180810-x86_64-2-Access2-GP2
./scripts/get_amis_list.py --rhel \
Atomic-7.5_HVM_GA-20180815-x86_64-0-Access2-GP2
./scripts/get_amis_list.py --rhel \
RHEL-7.5_HVM-20180813-x86_64-0-Access2-GP2

The script had to be modified to accept AMI descriptions starting with
"Atomic", though, as that's how the new Atomic AMI starts with.

Also, the 6.10 AMI is missing from ap-northeast-1, so I used the closest
one (*-0-Access2-GP2) for now.