### PR TITLE
add test coverage for custom GPG key handling

### DIFF
--- a/docs/gpg.rst
+++ b/docs/gpg.rst
@@ -1,0 +1,6 @@
+Custom GPG Key Verification Tests
+=================================
+
+.. automodule:: rhui3_tests.test_gpg
+   :members:
+   :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Welcome to RHUI3 Test Plan!
    client_management
    cmdline
    entitlements
+   gpg
    hap
    repo_management
    sosreport

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,7 +32,8 @@ In addition, you need a ZIP file with the following files in the root of the arc
 * `rhcert_incompatible.pem` — This must be a Red Hat content certificate containing one or more entitlements that are not compatible with RHUI (containing a non-RHUI repository path) and no compatible entitlement at all.
 * `rhcert_partially_invalid.pem` — This must be a Red Hat content certificate containing one or more entitlements that are not compatible with RHUI (containing a non-RHUI repository path) but also at least one compatible entitlement.
 * `rhui-rpm-upload-test-1-1.noarch.rpm` — This package will be uploaded to a custom repository.
-* `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository.
+* `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository. It must be signed with the RHUI QE GPG key.
+* `test_gpg_key` — This is the RHUI QE public GPG key (0x9F6E93A2).
 
 Lastly, in order for the subscription test to be able to run, you need a file with valid Red Hat credentials allowing access to RHUI. The file must look like this:
 

--- a/tests/rhui3_tests/test_gpg.py
+++ b/tests/rhui3_tests/test_gpg.py
@@ -1,0 +1,150 @@
+'''Tests for working with a custom GPG key in a custom repo'''
+
+from os.path import basename
+
+import logging
+import stitches
+from stitches.expect import Expect
+
+from rhui3_tests_lib.rhuimanager import RHUIManager
+from rhui3_tests_lib.rhuimanager_client import RHUIManagerClient
+from rhui3_tests_lib.rhuimanager_instance import RHUIManagerInstance
+from rhui3_tests_lib.rhuimanager_repo import RHUIManagerRepo
+from rhui3_tests_lib.util import Util
+
+logging.basicConfig(level=logging.DEBUG)
+
+RHUA = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+CLI = stitches.Connection("cli01.example.com", "root", "/root/.ssh/id_rsa_test")
+
+REPO = "custom_gpg"
+SIG = "9f6e93a2"
+SIGNED_PACKAGE = "rhui-rpm-upload-trial"
+UNSIGNED_PACKAGE = "rhui-rpm-upload-test"
+
+def setup():
+    '''
+       announce the beginning of the test run
+    '''
+    print("*** Running %s: *** " % basename(__file__))
+
+def test_01_initial_run():
+    '''
+        log in to RHUI
+    '''
+    RHUIManager.initial_run(RHUA)
+
+def test_02_add_cds():
+    '''
+        add a CDS
+    '''
+    RHUIManagerInstance.add_instance(RHUA, "cds", "cds01.example.com")
+
+def test_03_add_hap():
+    '''
+        add an HAProxy Load-balancer
+    '''
+    RHUIManagerInstance.add_instance(RHUA, "loadbalancers", "hap01.example.com")
+
+def test_04_create_custom_repo():
+    '''
+        add a custom repo using a custom GPG key
+    '''
+    RHUIManagerRepo.add_custom_repo(RHUA,
+                                    REPO,
+                                    redhat_gpg="n",
+                                    custom_gpg="/tmp/extra_rhui_files/test_gpg_key")
+
+def test_05_upload_to_custom_repo():
+    '''
+        upload a signed and an unsigned package to the custom repo
+    '''
+    RHUIManagerRepo.upload_content(RHUA,
+                                   [REPO],
+                                   "/tmp/extra_rhui_files/%s-1-1.noarch.rpm" % SIGNED_PACKAGE)
+    RHUIManagerRepo.upload_content(RHUA,
+                                   [REPO],
+                                   "/tmp/extra_rhui_files/%s-1-1.noarch.rpm" % UNSIGNED_PACKAGE)
+
+def test_06_display_detailed_info():
+    '''
+        Check detailed information on the repo
+    '''
+    RHUIManagerRepo.check_detailed_information(RHUA,
+                                               [REPO, REPO],
+                                               [True, True],
+                                               [True, "test_gpg_key", False],
+                                               2)
+
+def test_07_generate_ent_cert():
+    '''
+        generate an entitlement certificate
+    '''
+    RHUIManagerClient.generate_ent_cert(RHUA, [REPO], REPO, "/tmp")
+
+def test_08_create_cli_rpm():
+    '''
+        create a client configuration RPM
+    '''
+    RHUIManagerClient.create_conf_rpm(RHUA,
+                                      "/tmp",
+                                      "/tmp/%s.crt" % REPO,
+                                      "/tmp/%s.key" % REPO,
+                                      REPO)
+
+def test_09_rm_amazon_rhui_cf_rpm():
+    '''
+       remove Amazon RHUI configuration from the client
+    '''
+    Util.remove_amazon_rhui_conf_rpm(CLI)
+
+def test_10_install_conf_rpm():
+    '''
+       install the client configuration RPM
+    '''
+    Util.install_pkg_from_rhua(RHUA,
+                               CLI,
+                               "/tmp/%s-2.0/build/RPMS/noarch/%s-2.0-1.noarch.rpm" % (REPO, REPO))
+
+def test_11_install_signed_pkg():
+    '''
+       install the signed package from the custom repo (will import the GPG key)
+    '''
+    Expect.expect_retval(CLI, "yum -y install %s" % SIGNED_PACKAGE)
+
+def test_12_check_gpg_sig():
+    '''
+       check the signature in the installed package
+    '''
+    Expect.expect_retval(CLI, "rpm -qi rhui-rpm-upload-trial | grep -q ^Signature.*%s$" % SIG)
+
+def test_13_check_gpg_pubkey():
+    '''
+       check if the public GPG key was imported
+    '''
+    Expect.expect_retval(CLI, "rpm -q gpg-pubkey-%s" % SIG)
+
+def test_14_install_unsigned_pkg():
+    '''
+       try installing the unsigned package, should not work
+    '''
+    Expect.ping_pong(CLI,
+                     "yum -y install %s" % UNSIGNED_PACKAGE,
+                     "Package %s-1-1.noarch.rpm is not signed" % UNSIGNED_PACKAGE)
+    Expect.expect_retval(CLI, "rpm -q %s" % UNSIGNED_PACKAGE, 1)
+
+def test_99_cleanup():
+    '''
+       clean up
+    '''
+    RHUIManagerRepo.delete_all_repos(RHUA)
+    RHUIManagerInstance.delete(RHUA, "loadbalancers", ["hap01.example.com"])
+    RHUIManagerInstance.delete(RHUA, "cds", ["cds01.example.com"])
+    Expect.expect_retval(RHUA, "rm -rf /tmp/%s*" % REPO)
+    Util.remove_rpm(CLI, [SIGNED_PACKAGE, "gpg-pubkey-%s" % SIG, REPO])
+
+def teardown():
+    '''
+       announce the end of the test run
+    '''
+    print("*** Finished running %s. *** " % basename(__file__))


### PR DESCRIPTION
Custom repos can use a custom GPG key to verify the authenticity of custom packages. When a custom repo is created this way, the client configuration RPM then contains the custom key (in `/etc/pki/rpm-gpg/RPM-GPG-KEY-<name>`) and the `/etc/yum.repos.d/rh-cloud.repo` file with a line like this:

```
gpgcheck=1
gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-<name>
```
Then, Yum will require that all packages coming from this repo be signed with this key (that is, with the private counterpart of this key).

I've already put such a signed package and the public key to extra_files.zip, and now I'm proposing a test to cover this use case. Here's the output from the test:

```
*** Running test_gpg.py: *** 
log in to RHUI ... ok
add a CDS ... ok
add an HAProxy Load-balancer ... ok
add a custom repo using a custom GPG key ... ok
upload a signed and an unsigned package to the custom repo ... ok
Check detailed information on the repo ... ok
generate an entitlement certificate ... ok
create a client configuration RPM ... ok
remove amazon rhui configuration rpm from client ... ok
install configuration rpm to client ... ok
install the signed package from the custom repo (will import the GPG key) ... ok
check the signature in the installed package ... ok
check if the public GPG key was installed ... ok
try installing the unsigned package, should not work ... ok
clean up ... ok
*** Finished running test_gpg.py. *** 

----------------------------------------------------------------------
Ran 15 tests in 134.697s

OK
```

Adding a Sphinx doc file, too. (tested, too)