### PR TITLE
implement and modify test cases for RHUI 3.0.5

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -128,5 +128,5 @@
   tags: tests
 
 - name: run tests suite
-  shell: nosetests -vs /usr/share/rhui3_tests_lib/rhui3_tests &>>/tmp/rhui3test.log
+  shell: PYTHONUNBUFFERED=1 nosetests -vs /usr/share/rhui3_tests_lib/rhui3_tests &>>/tmp/rhui3test.log
   tags: run_tests

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -1,0 +1,6 @@
+Docker Container Management Tests
+=================================
+
+.. automodule:: rhui3_tests.test_docker
+   :members:
+   :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Welcome to RHUI3 Test Plan!
    cds
    client_management
    cmdline
+   docker
    entitlements
    gpg
    hap
@@ -23,6 +24,7 @@ Welcome to RHUI3 Test Plan!
    subscription
    sync_management
    user_management
+   zzz_misc
    
 
 

--- a/docs/zzz_misc.rst
+++ b/docs/zzz_misc.rst
@@ -1,0 +1,6 @@
+Miscellaneous Tests That Do Not Fit Elsewhere
+=============================================
+
+.. automodule:: rhui3_tests.test_zzz_misc
+   :members:
+   :undoc-members:

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,7 +26,7 @@ In addition, you need a ZIP file with the following files in the root of the arc
   * _Red Hat Enterprise Linux for SAP (RHEL 7 Server) (RPMs) from RHUI_
 * `rhcert_atomic.pem` — This must be a valid Red Hat content certificate allowing access to the following products:
   * _Red Hat Enterprise Linux Atomic Host (Trees) from RHUI_
-  * _Red Hat Enterprise Linux Atomic Host (Debug RPMs) from RHUI_
+  * _Red Hat Enterprise Linux Atomic Host Beta (Source RPMs) from RHUI_
   * _Red Hat Enterprise Linux Atomic Host (RPMs) from RHUI_
 * `rhcert_expired.pem` — This must be an expired Red Hat content certificate.
 * `rhcert_incompatible.pem` — This must be a Red Hat content certificate containing one or more entitlements that are not compatible with RHUI (containing a non-RHUI repository path) and no compatible entitlement at all.

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -23,7 +23,6 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 CONNECTION = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 CLI = stitches.Connection("cli01.example.com", "root", "/root/.ssh/id_rsa_test")
-ATOMIC_CLI = stitches.Connection("atomiccli.example.com", "root", "/root/.ssh/id_rsa_test")
 
 TEST_PACKAGE = "vm-dump-metrics"
 
@@ -201,37 +200,7 @@ class TestClient(object):
         '''
         Expect.expect_retval(CLI, "yum install -y " + TEST_PACKAGE, timeout=20)
 
-    @staticmethod
-    def test_15_create_docker_cli_rpm():
-        '''
-           create a docker client configuration RPM
-        '''
-        RHUIManagerClient.create_docker_conf_rpm(CONNECTION, "/root", "test_docker_cli_rpm", "4.0")
-        Expect.expect_retval(CONNECTION,
-                             "test -f /root/test_docker_cli_rpm-4.0/build/RPMS/noarch/" +
-                             "test_docker_cli_rpm-4.0-1.noarch.rpm")
-
-    def test_16_install_docker_rpm(self):
-        '''
-           install a docker client configuration RPM to client
-        '''
-        if self.rhua_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.rhua_os_version))
-        Util.install_pkg_from_rhua(CONNECTION,
-                                   CLI,
-                                   "/root/test_docker_cli_rpm-4.0/build/RPMS/noarch/" +
-                                   "test_docker_cli_rpm-4.0-1.noarch.rpm")
-
-    def test_17_check_docker_rpm_ver(self):
-        '''
-           check docker rpm version
-        '''
-        if self.rhua_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.rhua_os_version))
-        Expect.expect_retval(CLI, "[ `rpm "+
-                             "-q --queryformat \"%{VERSION}\" test_docker_cli_rpm` = '4.0' ]")
-
-    def test_18_unauthorized_access(self):
+    def test_15_unauthorized_access(self):
         '''
            verify that RHUI repo content cannot be fetched without an entitlement certificate
         '''
@@ -252,7 +221,7 @@ class TestClient(object):
                                  verify=False)
 
     @staticmethod
-    def test_19_check_cli_plugins():
+    def test_16_check_cli_plugins():
         '''
            check if irrelevant Yum plug-ins are not enabled on the client with the config RPM
         '''
@@ -262,7 +231,7 @@ class TestClient(object):
                              "egrep '^Loaded plugins.*(rhnplugin|subscription-manager)'", 1)
 
     @staticmethod
-    def test_20_release_handling():
+    def test_17_release_handling():
         '''
            check EUS release handling (working with /etc/yum/vars/releasever on the client)
         '''
@@ -294,9 +263,6 @@ class TestClient(object):
         RHUIManagerInstance.delete(CONNECTION, "cds", ["cds01.example.com"])
         Expect.expect_retval(CONNECTION, "rm -f /root/test_ent_cli*")
         Expect.expect_retval(CONNECTION, "rm -rf /root/test_cli_rpm-3.0/")
-        Expect.expect_retval(CONNECTION, "rm -rf /root/test_docker_cli_rpm-4.0/")
-        if self.rhua_os_version >= 7:
-            Util.remove_rpm(CLI, ["test_docker_cli_rpm"])
         Util.remove_rpm(CLI, [TEST_PACKAGE, "test_cli_rpm", "rhui-rpm-upload-test"])
         RHUIManager.remove_rh_certs(CONNECTION)
 

--- a/tests/rhui3_tests/test_docker.py
+++ b/tests/rhui3_tests/test_docker.py
@@ -142,7 +142,7 @@ class TestClient(object):
         '''
         if self.cli_os_version < 7:
             raise nose.exc.SkipTest("Not supported on RHEL " + str(self.cli_os_version))
-        Expect.ping_pong(CLI, "docker run rhel7-minimal-from-rhui uname", "Linux")
+        Expect.ping_pong(CLI, "docker run %s uname" % self.docker_container_id, "Linux")
 
     def test_99_cleanup(self):
         '''

--- a/tests/rhui3_tests/test_docker.py
+++ b/tests/rhui3_tests/test_docker.py
@@ -107,7 +107,7 @@ class TestClient(object):
            install the Docker client configuration RPM
         '''
         if self.cli_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+            raise nose.exc.SkipTest("Not supported on RHEL " + str(self.cli_os_version))
         Util.install_pkg_from_rhua(RHUA,
                                    CLI,
                                    CONF_RPM_PATH)
@@ -117,7 +117,7 @@ class TestClient(object):
            restart the Docker service for the configuration to take effect
         '''
         if self.cli_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+            raise nose.exc.SkipTest("Not supported on RHEL " + str(self.cli_os_version))
         Expect.expect_retval(CLI, "systemctl restart docker")
 
     def test_11_pull_image(self):
@@ -125,7 +125,7 @@ class TestClient(object):
            pull the Docker container
         '''
         if self.cli_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+            raise nose.exc.SkipTest("Not supported on RHEL " + str(self.cli_os_version))
         Expect.expect_retval(CLI, "docker pull %s" % self.docker_container_id, timeout=30)
 
     def test_12_check_image(self):
@@ -133,7 +133,7 @@ class TestClient(object):
            check if the container is now available
         '''
         if self.cli_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+            raise nose.exc.SkipTest("Not supported on RHEL " + str(self.cli_os_version))
         Expect.ping_pong(CLI, "docker images", "cds.example.com:5000/%s" % self.docker_container_id)
 
     def test_13_run_command(self):
@@ -141,7 +141,7 @@ class TestClient(object):
            run a test command (uname) in the container
         '''
         if self.cli_os_version < 7:
-            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+            raise nose.exc.SkipTest("Not supported on RHEL " + str(self.cli_os_version))
         Expect.ping_pong(CLI, "docker run rhel7-minimal-from-rhui uname", "Linux")
 
     def test_99_cleanup(self):

--- a/tests/rhui3_tests/test_docker.py
+++ b/tests/rhui3_tests/test_docker.py
@@ -1,0 +1,167 @@
+'''Docker Container Management Tests'''
+
+from os.path import basename
+
+import logging
+import nose
+import stitches
+from stitches.expect import Expect
+import yaml
+
+from rhui3_tests_lib.rhuimanager import RHUIManager
+from rhui3_tests_lib.rhuimanager_client import RHUIManagerClient
+from rhui3_tests_lib.rhuimanager_instance import RHUIManagerInstance
+from rhui3_tests_lib.rhuimanager_repo import RHUIManagerRepo
+from rhui3_tests_lib.rhuimanager_sync import RHUIManagerSync
+from rhui3_tests_lib.util import Util
+
+logging.basicConfig(level=logging.DEBUG)
+
+RHUA = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+CLI = stitches.Connection("cli01.example.com", "root", "/root/.ssh/id_rsa_test")
+
+CONF_RPM_NAME = "docker-rhui"
+CONF_RPM_PATH = "/tmp/%s-2.0/build/RPMS/noarch/%s-2.0-1.noarch.rpm" % (CONF_RPM_NAME, CONF_RPM_NAME)
+
+class TestClient(object):
+    '''
+       class for Docker container tests
+    '''
+
+    def __init__(self):
+        self.cli_os_version = Util.get_rhua_version(CLI)["major"]
+
+        with open('/usr/share/rhui3_tests_lib/config/tested_repos.yaml', 'r') as configfile:
+            doc = yaml.load(configfile)
+
+        self.docker_container_name = doc['docker_container2']['name']
+        self.docker_container_id = doc['docker_container2']['id']
+        self.docker_container_displayname = doc['docker_container2']['displayname']
+
+    @staticmethod
+    def setup_class():
+        '''
+           announce the beginning of the test run
+        '''
+        print("*** Running %s: *** " % basename(__file__))
+
+    @staticmethod
+    def test_01_init():
+        '''log in to rhui-manager'''
+        RHUIManager.initial_run(RHUA)
+
+    @staticmethod
+    def test_02_add_cds():
+        '''
+            add a CDS
+        '''
+        RHUIManagerInstance.add_instance(RHUA, "cds", "cds01.example.com")
+
+    @staticmethod
+    def test_04_add_hap():
+        '''
+            add an HAProxy Load-balancer
+        '''
+        RHUIManagerInstance.add_instance(RHUA, "loadbalancers", "hap01.example.com")
+
+    def test_05_add_container(self):
+        '''
+           add a Docker container
+        '''
+        RHUIManagerRepo.add_docker_container(RHUA,
+                                             self.docker_container_name,
+                                             self.docker_container_id,
+                                             self.docker_container_displayname)
+
+    def test_06_display_container(self):
+        '''
+           check detailed information on the Docker container
+        '''
+        RHUIManagerRepo.check_detailed_information(RHUA,
+                                                   [self.docker_container_displayname,
+                                                    "https://cds.example.com/pulp/docker/%s/" % \
+                                                    self.docker_container_id],
+                                                   [False],
+                                                   [True, None, True],
+                                                   0)
+
+    def test_07_sync_container(self):
+        '''
+           sync the Docker container
+        '''
+        RHUIManagerSync.sync_repo(RHUA, [self.docker_container_displayname])
+        RHUIManagerSync.wait_till_repo_synced(RHUA, [self.docker_container_displayname])
+
+    @staticmethod
+    def test_08_create_docker_cli_rpm():
+        '''
+           create a Docker client configuration RPM
+        '''
+        RHUIManagerClient.create_docker_conf_rpm(RHUA,
+                                                 "/tmp",
+                                                 CONF_RPM_NAME)
+        Expect.expect_retval(RHUA, "test -f %s" % CONF_RPM_PATH)
+
+    def test_09_install_docker_cli_rpm(self):
+        '''
+           install the Docker client configuration RPM
+        '''
+        if self.cli_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+        Util.install_pkg_from_rhua(RHUA,
+                                   CLI,
+                                   CONF_RPM_PATH)
+
+    def test_10_restart_docker_service(self):
+        '''
+           restart the Docker service for the configuration to take effect
+        '''
+        if self.cli_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+        Expect.expect_retval(CLI, "systemctl restart docker")
+
+    def test_11_pull_image(self):
+        '''
+           pull the Docker container
+        '''
+        if self.cli_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+        Expect.expect_retval(CLI, "docker pull %s" % self.docker_container_id, timeout=30)
+
+    def test_12_check_image(self):
+        '''
+           check if the container is now available
+        '''
+        if self.cli_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+        Expect.ping_pong(CLI, "docker images", "cds.example.com:5000/%s" % self.docker_container_id)
+
+    def test_13_run_command(self):
+        '''
+           run a test command (uname) in the container
+        '''
+        if self.cli_os_version < 7:
+            raise nose.exc.SkipTest('Not supported on RHEL ' + str(self.cli_os_version))
+        Expect.ping_pong(CLI, "docker run rhel7-minimal-from-rhui uname", "Linux")
+
+    def test_99_cleanup(self):
+        '''
+           remove the container from RHUA and the client, restart docker, uninstall HAProxy and CDS
+        '''
+        if self.cli_os_version >= 7:
+            Expect.expect_retval(CLI, "docker rm $(docker ps -a -f ancestor=%s -q)" % \
+                                 self.docker_container_id)
+            Expect.expect_retval(CLI, "docker rmi %s" % self.docker_container_id)
+            Util.remove_rpm(CLI, [CONF_RPM_NAME])
+            Expect.expect_retval(CLI, "systemctl restart docker")
+        Expect.expect_retval(RHUA, "rm -rf /tmp/%s*" % CONF_RPM_NAME)
+        RHUIManagerRepo.delete_all_repos(RHUA)
+        RHUIManagerInstance.delete(RHUA, "loadbalancers", ["hap01.example.com"])
+        RHUIManagerInstance.delete(RHUA, "cds", ["cds01.example.com"])
+
+    @staticmethod
+    def teardown_class():
+        '''
+           announce the end of the test run
+        '''
+        print("*** Finished running %s. *** " % basename(__file__))

--- a/tests/rhui3_tests/test_sosreport.py
+++ b/tests/rhui3_tests/test_sosreport.py
@@ -6,23 +6,37 @@ from os.path import basename, join
 from shutil import rmtree
 from tempfile import mkdtemp
 
+import nose
 import stitches
 from stitches.expect import Expect
 
+from rhui3_tests_lib.rhuimanager import RHUIManager
+from rhui3_tests_lib.rhuimanager_instance import RHUIManagerInstance
 from rhui3_tests_lib.sos import Sos
+from rhui3_tests_lib.util import Util
 
 logging.basicConfig(level=logging.DEBUG)
 
 TMPDIR = mkdtemp()
 SOSREPORT_FILELIST = join(TMPDIR, "sosreport_filelist")
-SOSREPORT_LOCATION = join(TMPDIR, "sosreport_location")
+SOSREPORT_LOCATION_RHUA = join(TMPDIR, "sosreport_location_rhua")
+SOSREPORT_LOCATION_CDS = join(TMPDIR, "sosreport_location_cds")
 
 CONNECTION_RHUA = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+CONNECTION_CDS = stitches.Connection("cds01.example.com", "root", "/root/.ssh/id_rsa_test")
+
 WANTED_FILES_RHUA = ["/etc/rhui-installer/answers.yaml",
                      "/etc/rhui/rhui-tools.conf",
                      "/root/.rhui/rhui.log",
                      "/var/log/kafo/configuration.log",
-                     "/var/log/rhui-subscription-sync.log"]
+                     "/var/log/rhui-subscription-sync.log",
+                     "/rhui-manager_status"]
+WANTED_FILES_CDS = ["/etc/httpd/conf.d/03-crane.conf",
+                    "/etc/httpd/conf.d/25-cds.example.com.conf",
+                    "/etc/pulp/",
+                    "/var/log/httpd/cds.example.com_access_ssl.log",
+                    "/var/log/httpd/cds.example.com_error_ssl.log",
+                    "ls_-lR_var.lib.rhui.remote_share"]
 
 def setup():
     '''
@@ -30,34 +44,43 @@ def setup():
     '''
     print("*** Running %s: *** " % basename(__file__))
 
-def test_00_rhui_subscription_sync():
+def test_00_rhui_init():
     '''
-        run the rhui-subscription-sync command on the RHUA node to ensure its log file exists
+        add a CDS and run rhui-subscription-sync to ensure their log files exist
     '''
+    #  use initial_run first to ensure we're logged in to rhui-manager
+    RHUIManager.initial_run(CONNECTION_RHUA)
+    RHUIManagerInstance.add_instance(CONNECTION_RHUA, "cds", "cds01.example.com")
     # can't use expect_retval as the exit code can be 0 or 1 (sync is configured or unconfigured)
     Expect.ping_pong(CONNECTION_RHUA,
                      "rhui-subscription-sync ; echo ACK",
                      "ACK")
 
-def test_01_rhua_sosreport_run():
+def test_01_rhua_check_sos_script():
+    '''
+        check if the RHUI sosreport script is available on the RHUA node
+    '''
+    Sos.check_rhui_sos_script(CONNECTION_RHUA)
+
+def test_02_rhua_sosreport_run():
     '''
         run sosreport on the RHUA node
     '''
     sosreport_location = Sos.run(CONNECTION_RHUA)
-    with open(SOSREPORT_LOCATION, "w") as location:
+    with open(SOSREPORT_LOCATION_RHUA, "w") as location:
         location.write(sosreport_location)
 
-def test_02_rhua_fetch_filelist():
+def test_03_rhua_fetch_filelist():
     '''
        fetch a list of files collected in the sosreport archive
     '''
-    with open(SOSREPORT_LOCATION) as location:
+    with open(SOSREPORT_LOCATION_RHUA) as location:
         sosreport_file = location.read()
     sosreport_filelist = Sos.list_contents(CONNECTION_RHUA, sosreport_file)
     with open(SOSREPORT_FILELIST, "w") as filelist:
         filelist.write(sosreport_filelist)
 
-def test_03_rhua_sosreport_check():
+def test_04_rhua_sosreport_check():
     '''
         check if the sosreport archive from the RHUA node contains the desired files
     '''
@@ -65,17 +88,60 @@ def test_03_rhua_sosreport_check():
         sosreport_filelist = filelist.read()
     Sos.check_files_in_archive(WANTED_FILES_RHUA, sosreport_filelist)
 
+def test_05_cds_check_sos_script():
+    '''
+        check if the RHUI sosreport script is available on the CDS node
+    '''
+    # for RHBZ#1596296
+    Sos.check_rhui_sos_script(CONNECTION_CDS)
+
+def test_06_cds_sosreport_run():
+    '''
+        run sosreport on the CDS node
+    '''
+    sosreport_location = Sos.run(CONNECTION_CDS)
+    with open(SOSREPORT_LOCATION_CDS, "w") as location:
+        location.write(sosreport_location)
+
+def test_07_cds_fetch_filelist():
+    '''
+       fetch a list of files collected in the sosreport archive
+    '''
+    with open(SOSREPORT_LOCATION_CDS) as location:
+        sosreport_file = location.read()
+    sosreport_filelist = Sos.list_contents(CONNECTION_CDS, sosreport_file)
+    with open(SOSREPORT_FILELIST, "w") as filelist:
+        filelist.write(sosreport_filelist)
+
+def test_08_cds_sosreport_check():
+    '''
+        check if the sosreport archive from the CDS node contains the desired files
+    '''
+    cds_rhel_version = Util.get_rhua_version(CONNECTION_CDS)
+    if cds_rhel_version["major"] == 7 and cds_rhel_version["minor"] < 6:
+        raise nose.exc.SkipTest("N/A here until RHBZ#1596494 is fixed.")
+    with open(SOSREPORT_FILELIST) as filelist:
+        sosreport_filelist = filelist.read()
+    Sos.check_files_in_archive(WANTED_FILES_CDS, sosreport_filelist)
+
 def test_99_cleanup():
     '''
-        clean up temporary files (the archive and its checksum file from the RHUA, local caches)
+        delete the archives and their checksum files, local caches; remove CDS
     '''
-    with open(SOSREPORT_LOCATION) as location:
+    with open(SOSREPORT_LOCATION_RHUA) as location:
         sosreport_file = location.read()
     Expect.ping_pong(CONNECTION_RHUA,
                      "rm -f " + sosreport_file + "* ; " +
                      "ls " + sosreport_file + "* 2>&1",
                      "No such file or directory")
+    with open(SOSREPORT_LOCATION_CDS) as location:
+        sosreport_file = location.read()
+    Expect.ping_pong(CONNECTION_CDS,
+                     "rm -f " + sosreport_file + "* ; " +
+                     "ls " + sosreport_file + "* 2>&1",
+                     "No such file or directory")
     rmtree(TMPDIR)
+    RHUIManagerInstance.delete(CONNECTION_RHUA, "cds", ["cds01.example.com"])
 
 def teardown():
     '''

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -91,6 +91,8 @@ class TestSubscription(object):
             unregister the subscription in RHUI
         '''
         RHUIManagerSubMan.subscriptions_unregister(CONNECTION, [self.subscription_name_1])
+        # also delete the cert file
+        RHUIManager.remove_rh_certs(CONNECTION)
 
     @staticmethod
     def test_08_check_registered_subs():

--- a/tests/rhui3_tests/test_zzz_misc.py
+++ b/tests/rhui3_tests/test_zzz_misc.py
@@ -72,8 +72,8 @@ def test_03_restart_services_script():
     # the new PIDs must differ and mustn't be 0, which would mean the pidfile couldn't be read
     # (which would mean the service didn't (re)start)
     for i in range(len(RHUI_SERVICE_PIDFILES)):
-        nose.tools.ok_(new_pids[i] != old_pids[i])
-        nose.tools.ok_(new_pids[i] > 0)
+        nose.tools.ok_(new_pids[i] != old_pids[i], msg="not all the RHUI services restarted")
+        nose.tools.ok_(new_pids[i] > 0, msg="not all the RHUI services started")
 
 def test_04_fabric_crypto_req():
     '''
@@ -89,13 +89,10 @@ def test_05_celery_selinux():
     # for RHBZ#1608166 - anyway, only non-fatal denials are expected if everything else works
     rhua_rhel_version = Util.get_rhua_version(RHUA)["major"]
     if rhua_rhel_version < 7:
-        Expect.ping_pong(RHUA,
-                         "grep celery /var/log/audit/audit.log | audit2allow",
-                         r"audit2allow\r\n\r\n\r\n\[root@rhua ~\]")
+        output = r"audit2allow\r\n\r\n\r\n\[root@rhua ~\]"
     else:
-        Expect.ping_pong(RHUA,
-                         "grep celery /var/log/audit/audit.log | audit2allow",
-                         "Nothing to do")
+        output = "Nothing to do"
+    Expect.ping_pong(RHUA, "grep celery /var/log/audit/audit.log | audit2allow", output)
 
 def teardown():
     '''

--- a/tests/rhui3_tests/test_zzz_misc.py
+++ b/tests/rhui3_tests/test_zzz_misc.py
@@ -1,0 +1,104 @@
+'''Miscellaneous Tests That Do Not Fit Elsewhere'''
+
+import json
+from os.path import basename
+
+import nose
+import stitches
+from stitches.expect import Expect
+
+from rhui3_tests_lib.util import Util
+
+RHUA = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+
+RHUI_SERVICE_PIDFILES = ["/var/run/httpd/httpd.pid",
+                         "/var/run/pulp/celerybeat.pid",
+                         "/var/run/pulp/reserved_resource_worker-0.pid",
+                         "/var/run/pulp/reserved_resource_worker-1.pid",
+                         "/var/run/pulp/reserved_resource_worker-2.pid",
+                         "/var/run/pulp/resource_manager.pid"]
+
+def setup():
+    '''
+       announce the beginning of the test run
+    '''
+    print("*** Running %s: *** " % basename(__file__))
+
+def test_01_sha1():
+    '''
+        check if SHA-1 is not used in internal certificates, and if SHA-256 is used instead
+    '''
+    # for RHBZ#1411451
+    Expect.expect_retval(RHUA,
+                         "grep -q 'Signature Algorithm: sha1' " +
+                         "/etc/pki/katello-certs-tools/certs/*.crt " +
+                         "/etc/puppet/rhui-secrets/cds-cert.crt",
+                         1)
+    Expect.expect_retval(RHUA,
+                         "grep -q 'Signature Algorithm: sha256' " +
+                         "/etc/pki/katello-certs-tools/certs/*.crt " +
+                         "/etc/puppet/rhui-secrets/cds-cert.crt")
+
+def test_02_repo_remove_missing():
+    '''
+        check if Pulp repos are globally configured to remove packages missing upstream
+    '''
+    # for RHBZ#1489113
+    _, stdout, _ = RHUA.exec_command("cat /etc/pulp/server/plugins.conf.d/yum_importer.json")
+    with stdout as cfgfile:
+        cfg = json.load(cfgfile)
+    nose.tools.ok_("remove_missing" in cfg, msg="'remove_missing' is not in the configuration")
+    nose.tools.ok_(cfg["remove_missing"], msg="'remove_missing' is not enabled")
+
+def test_03_restart_services_script():
+    '''
+        try the rhui-services-restart script
+    '''
+    # for RHBZ#1539105
+    Expect.ping_pong(RHUA, "rhui-services-restart --help", "Usage:")
+    # fetch current service PIDs
+    # use 0 if a PID file doesn't exist (the service isn't running)
+    _, stdout, _ = RHUA.exec_command("for pidfile in %s; do cat $pidfile || echo 0; done" % \
+                                     " ".join(RHUI_SERVICE_PIDFILES))
+    with stdout as output:
+        old_pids = list(map(int, output.read().decode().splitlines()))
+    # restart
+    Expect.expect_retval(RHUA, "rhui-services-restart", timeout=30)
+    # fetch new service PIDs
+    _, stdout, _ = RHUA.exec_command("for pidfile in %s; do cat $pidfile || echo 0; done" % \
+                                     " ".join(RHUI_SERVICE_PIDFILES))
+    with stdout as output:
+        new_pids = list(map(int, output.read().decode().splitlines()))
+    # the new PIDs must differ and mustn't be 0, which would mean the pidfile couldn't be read
+    # (which would mean the service didn't (re)start)
+    for i in range(len(RHUI_SERVICE_PIDFILES)):
+        nose.tools.ok_(new_pids[i] != old_pids[i])
+        nose.tools.ok_(new_pids[i] > 0)
+
+def test_04_fabric_crypto_req():
+    '''
+        check if the fabric package requires python-crypto
+    '''
+    # for RHBZ#1615907
+    Expect.expect_retval(RHUA, "rpm -qR fabric | grep -q python-crypto")
+
+def test_05_celery_selinux():
+    '''
+        verify that no SELinux denial related to celery was logged
+    '''
+    # for RHBZ#1608166 - anyway, only non-fatal denials are expected if everything else works
+    rhua_rhel_version = Util.get_rhua_version(RHUA)["major"]
+    if rhua_rhel_version < 7:
+        Expect.ping_pong(RHUA,
+                         "grep celery /var/log/audit/audit.log | audit2allow",
+                         r"audit2allow\r\n\r\n\r\n\[root@rhua ~\]")
+    else:
+        Expect.ping_pong(RHUA,
+                         "grep celery /var/log/audit/audit.log | audit2allow",
+                         "Nothing to do")
+
+def teardown():
+    '''
+       announce the end of the test run
+    '''
+    print("*** Finished running %s. *** " % basename(__file__))

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -14,9 +14,9 @@ atomic_repo:
     remote: "rhui-rhel-atomic-host-rhui-ostree"
     ref: "rhel-atomic-host/7/x86_64/standard"
 CLI_repo1:
-    name: "Red Hat Enterprise Linux Atomic Host (Debug RPMs) from RHUI"
-    id: "rhel-atomic-host-rhui-debug-rpms-x86_64"
-    label: "rhel-atomic-host-rhui-debug-rpms"
+    name: "Red Hat Enterprise Linux Atomic Host Beta (Source RPMs) from RHUI"
+    id: "rhel-atomic-host-beta-rhui-source-rpms"
+    label: "rhel-atomic-host-beta-rhui-source-rpms"
 CLI_repo2:
     name: "Red Hat Enterprise Linux Atomic Host (RPMs) from RHUI (x86_64)"
     id: "rhel-atomic-host-rhui-rpms-x86_64"
@@ -26,3 +26,7 @@ subscription1:
 docker_container1:
     name: "rhcertification/redhat-certification"
     displayname: "RH Certification Docker"
+docker_container2:
+    name: "rhel7-minimal"
+    id: "rhel7-minimal-from-rhui"
+    displayname: "RHEL 7 Minimal"

--- a/tests/rhui3_tests_lib/rhuimanager_client.py
+++ b/tests/rhui3_tests_lib/rhuimanager_client.py
@@ -47,7 +47,12 @@ class RHUIManagerClient(object):
         Expect.enter(connection, certkey)
         if unprotected_repos:
             RHUIManager.select(connection, unprotected_repos)
-        RHUIManager.quit(connection)
+        if not rpmversion:
+            rpmversion = "2.0"
+        Expect.expect(connection,
+                      "Location: %s/%s-%s/build/RPMS/noarch/%s-%s-1.noarch.rpm" % \
+                      (dirname, rpmname, rpmversion, rpmname, rpmversion))
+        Expect.enter(connection, "q")
 
     @staticmethod
     def create_docker_conf_rpm(connection, dirname, rpmname, rpmversion="", dockerport=""):
@@ -64,7 +69,12 @@ class RHUIManagerClient(object):
         Expect.enter(connection, rpmversion)
         Expect.expect(connection, "Port to serve Docker content on .*:")
         Expect.enter(connection, dockerport)
-        RHUIManager.quit(connection)
+        if not rpmversion:
+            rpmversion = "2.0"
+        Expect.expect(connection,
+                      "Location: %s/%s-%s/build/RPMS/noarch/%s-%s-1.noarch.rpm" % \
+                      (dirname, rpmname, rpmversion, rpmname, rpmversion))
+        Expect.enter(connection, "q")
 
     @staticmethod
     def create_atomic_conf_pkg(connection, dirname, tarname, certpath, certkey, dockerport=""):
@@ -83,4 +93,7 @@ class RHUIManagerClient(object):
         Expect.enter(connection, certkey)
         Expect.expect(connection, "Port to serve Docker content on .*:")
         Expect.enter(connection, dockerport)
-        RHUIManager.quit(connection)
+        Expect.expect(connection,
+                      "Location: %s/%s.tar.gz" % \
+                      (dirname, tarname))
+        Expect.enter(connection, "q")

--- a/tests/rhui3_tests_lib/rhuimanager_cmdline.py
+++ b/tests/rhui3_tests_lib/rhuimanager_cmdline.py
@@ -80,20 +80,25 @@ class RHUIManagerCLI(object):
         with stdout as output:
             rawlist = output.read().decode().splitlines()
 
-        first_rh_repo = 4
-        for i in range(first_rh_repo, len(rawlist) - 3):
-            if rawlist[i] == "":
-                last_rh_repo = i - 1
+        # the first RH repo is on the 5th line (if there's a RH repo at all)
+        first_rh_repo_index = 4
+        # find the position of the last RH repo
+        for index in range(first_rh_repo_index, len(rawlist) - 3):
+            if rawlist[index] == "":
+                last_rh_repo_index = index - 1
                 break
-        first_custom_repo = last_rh_repo + 4
-        last_custom_repo = len(rawlist) - 2
+        # the first custom repo is 4 lines below the last RH repo
+        first_custom_repo_index = last_rh_repo_index + 4
+        # the last custom repo is 2 lines above the end of the output
+        last_custom_repo_index = len(rawlist) - 2
 
+        # parse the repo IDs and names
         rhrepos = []
-        for index in range(first_rh_repo, last_rh_repo + 1):
+        for index in range(first_rh_repo_index, last_rh_repo_index + 1):
             tmplist = rawlist[index].split("::")
             rhrepos.append([tmplist[0].strip(), tmplist[1].strip()])
         customrepos = []
-        for index in range(first_custom_repo, last_custom_repo + 1):
+        for index in range(first_custom_repo_index, last_custom_repo_index + 1):
             tmplist = rawlist[index].split("::")
             customrepos.append([tmplist[0].strip(), tmplist[1].strip()])
 

--- a/tests/rhui3_tests_lib/sos.py
+++ b/tests/rhui3_tests_lib/sos.py
@@ -8,6 +8,13 @@ class Sos(object):
         Sos handling for RHUI
     '''
     @staticmethod
+    def check_rhui_sos_script(connection):
+        '''
+            check if the RHUI sosreport script is available
+        '''
+        Expect.expect_retval(connection, "test -f /usr/share/rh-rhua/rhui-debug.py")
+
+    @staticmethod
     def run(connection):
         '''
             run the sosreport command

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -9,7 +9,7 @@ import sys
 
 from setuptools import setup
 
-REQUIREMENTS = ['nose>=1.3.0', 'stitches>=0.12']
+REQUIREMENTS = ['nose>=1.3.0', 'pytoml', 'requests', 'stitches>=0.12']
 
 # Workaround for https://github.com/paramiko/paramiko/issues/1123
 PYTHON_VERSION = sys.version_info[0] + sys.version_info[1] / 10.0


### PR DESCRIPTION
These changes reflect the bug fixes and enhancements brought by RHUI 3.0.5, which was released yesterday. They provide test coverage for all the improvements.

A couple of notes on things that may not be obvious:

- the basic Docker tests were taken out of client management. Together with real Docker client tests they're now in a dedicated file; note that this applies to normal RHEL client, whereas in the case of Atomic the file was modified to examine the Docker configuration created by the Atomic client tarball
- `PYTHONUNBUFFERED=1` was added because otherwise the log file contains all the headers and footers printed by `setup()` and `teardown()` at the end, as opposed to where they belong; this solution was found while implementing one of the RFEs (by me :) )
- one of the tested repos had to be replaced due to a change in the RHUI entitlement and a RHUI bug that was found (and reported (and not fixed)) during the testing
- the two tested repos in the CLI tests had to be swapped so they could be added in non-alphabetical order (so that sorting could be tested)
- introducing a new file for uncategorized tests; I expect this file to grow in the future