### PR TITLE
make sure vim is installed

### DIFF
--- a/deploy/roles/common/tasks/main.yml
+++ b/deploy/roles/common/tasks/main.yml
@@ -3,8 +3,10 @@
 # set up & configure ntp on all the hosts
 # set up custom DNS if requested
 # disable (or remove) cloud-init
+# install vim
 - include: upgrade_all_pkg.yml
 - include: ntp.yml
 - include: hosts.yml
 - include: dns_override.yml
 - include: cloud-init.yml
+- include: vim.yml

--- a/deploy/roles/common/tasks/vim.yml
+++ b/deploy/roles/common/tasks/vim.yml
@@ -1,0 +1,11 @@
+---
+# file: roles/common/tasks/vim.yml
+# install vim, which may not be installed by default but is so much better than vi
+# N/A to Atomic hosts as packages cannot be installed there
+
+- name: install vim
+  package:
+    name: vim
+    state: present
+  when: ansible_env.SUDO_USER != "cloud-user"
+  tags: vim


### PR DESCRIPTION
Vim isn't installed on RHEL 7 AMIs. Vi is, but it lacks _many_ features that vim has.

I often want to edit some files on RHUI nodes, and sometimes I use vi, but it's just not as good as vim. Or I install vim manually, but that's extra work. I suggest this task that will take care of the installation automatically; it can be skipped by those who don't like vim for any reason by Ansible's skip-tags feature.