### PR TITLE
raise an exception in add_custom_repo() if the repo exists

### DIFF
--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -10,7 +10,7 @@ import yaml
 
 from rhui3_tests_lib.rhuimanager import RHUIManager
 from rhui3_tests_lib.rhuimanager_entitlement import RHUIManagerEntitlements
-from rhui3_tests_lib.rhuimanager_repo import RHUIManagerRepo
+from rhui3_tests_lib.rhuimanager_repo import AlreadyExistsError, RHUIManagerRepo
 from rhui3_tests_lib.util import Util
 
 logging.basicConfig(level=logging.DEBUG)
@@ -84,13 +84,11 @@ class TestRepo(object):
 
     @staticmethod
     def test_05_repo_id_uniqueness():
-        '''check that the repo ID is unique'''
-        RHUIManagerRepo.add_custom_repo(CONNECTION,
-                                        "custom-i386-x86_64",
-                                        "",
-                                        "custom/i386/x86_64",
-                                        "1",
-                                        "y")
+        '''verify that rhui-manager refuses to create a custom repo whose name already exists'''
+        nose.tools.assert_raises(AlreadyExistsError,
+                                 RHUIManagerRepo.add_custom_repo,
+                                 CONNECTION,
+                                 "custom-i386-x86_64")
 
     @staticmethod
     def test_06_upload_to_custom_repo():

--- a/tests/rhui3_tests_lib/rhuimanager_repo.py
+++ b/tests/rhui3_tests_lib/rhuimanager_repo.py
@@ -6,10 +6,16 @@ import time
 
 import nose
 
-from stitches.expect import Expect
+from stitches.expect import CTRL_C, Expect
 
 from rhui3_tests_lib.rhuimanager import RHUIManager
 
+
+class AlreadyExistsError(Exception):
+    '''
+    To be raised if a custom repo already exists with this name.
+    '''
+    pass
 
 class RHUIManagerRepo(object):
     '''
@@ -37,7 +43,7 @@ class RHUIManagerRepo(object):
                                    [(re.compile(".*Display name for the custom repository.*:",
                                                 re.DOTALL),
                                      1),
-                                    (re.compile(".*Unique ID for the custom repository.*:",
+                                    (re.compile(".*repository.*already exists.*Unique ID.*:",
                                                 re.DOTALL),
                                      2)])
         if state == 1:
@@ -109,8 +115,9 @@ class RHUIManagerRepo(object):
                                            checklist)
             RHUIManager.quit(connection, "Successfully created repository *")
         else:
-            Expect.enter(connection, '\x03')
+            Expect.enter(connection, CTRL_C)
             RHUIManager.quit(connection)
+            raise AlreadyExistsError()
 
     @staticmethod
     def add_rh_repo_all(connection):


### PR DESCRIPTION
The `RHUIManagerRepo.add_custom_repo()` method silently passes if it's called with a repo name that already exists. That's better than getting a failure from `Expect`, but I think it would be even better if the method could behave differently in this case. I suggest raising an exception in the method, and calling the method using `nose.tools.assert_raises()` with an already existing repo. That way the exception will be expected and correctly handled. (Note that we already use `assert_raises()` in a few places for methods that are _supposed_ to raise a specific exception in a specific condition.)