### PR TITLE
test coverage for the rhui command (cds and haproxy management)

### DIFF
--- a/docs/cds_cmd.rst
+++ b/docs/cds_cmd.rst
@@ -1,0 +1,6 @@
+CDS Management Tests for the CLI
+================================
+
+.. automodule:: rhui3_tests.test_cds_cmd
+   :members:
+   :undoc-members:

--- a/docs/hap_cmd.rst
+++ b/docs/hap_cmd.rst
@@ -1,0 +1,6 @@
+HAProxy Management Tests for the CLI
+====================================
+
+.. automodule:: rhui3_tests.test_hap_cmd
+   :members:
+   :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,12 +13,14 @@ Welcome to the RHUI 3 Test Plan!
    
    atomic_client
    cds
+   cds_cmd
    client_management
    cmdline
    docker
    entitlements
    gpg
    hap
+   hap_cmd
    repo_management
    sosreport
    subscription

--- a/tests/rhui3_tests/test_cds_cmd.py
+++ b/tests/rhui3_tests/test_cds_cmd.py
@@ -1,0 +1,164 @@
+'''CDS management tests for the CLI'''
+
+from os.path import basename
+import random
+import re
+
+import logging
+import nose
+import stitches
+
+from rhui3_tests_lib.rhui_cmd import RHUICLI
+from rhui3_tests_lib.rhuimanager import RHUIManager
+
+logging.basicConfig(level=logging.DEBUG)
+
+CONNECTION = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+
+CDS_PATTERN = r"cds[0-9]+\.example\.com"
+with open("/etc/hosts") as hostsfile:
+    ALL_HOSTS = hostsfile.read()
+CDS_HOSTNAMES = re.findall(CDS_PATTERN, ALL_HOSTS)
+
+def setup():
+    '''
+    announce the beginning of the test run
+    '''
+    print("*** Running %s: *** " % basename(__file__))
+
+def test_01_init():
+    '''
+    log in to RHUI
+    '''
+    RHUIManager.initial_run(CONNECTION)
+
+def test_02_list_cds():
+    '''
+    check if there are no CDSs
+    '''
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    nose.tools.eq_(cds_list, [])
+
+def test_03_add_cds():
+    '''
+    add all known CDSs
+    '''
+    for cds in CDS_HOSTNAMES:
+        status = RHUICLI.add(CONNECTION, "cds", cds, unsafe=True)
+        nose.tools.ok_(status, msg="unexpected %s installation status: %s" % (cds, status))
+
+def test_04_list_cds():
+    '''
+    check if the CDSes have been added
+    '''
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    nose.tools.eq_(cds_list, CDS_HOSTNAMES)
+
+def test_05_reinstall_cds():
+    '''
+    add one of the CDSs again by reinstalling it
+    '''
+    # choose a random CDS hostname from the list
+    cds = random.choice(CDS_HOSTNAMES)
+    status = RHUICLI.reinstall(CONNECTION, "cds", cds)
+    nose.tools.ok_(status, msg="unexpected %s reinstallation status: %s" % (cds, status))
+
+def test_06_list_cds():
+    '''
+    check if the CDSs are still tracked, and nothing extra has appeared
+    '''
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    # the reinstalled CDS is now the last one in the list; the list may not be the same, sort it!
+    cds_list.sort()
+    nose.tools.eq_(cds_list, CDS_HOSTNAMES)
+
+def test_07_readd_cds_noforce():
+    '''
+    check if rhui refuses to add a CDS again if no extra parameter is used
+    '''
+    # again choose a random CDS hostname from the list
+    cds = random.choice(CDS_HOSTNAMES)
+    status = RHUICLI.add(CONNECTION, "cds", cds, unsafe=True)
+    nose.tools.ok_(not status, msg="unexpected %s readdition status: %s" % (cds, status))
+
+def test_08_list_cds():
+    '''
+    check if nothing extra has been added
+    '''
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    # the readded CDS is now the last one in the list; the list may not be the same, sort it!
+    cds_list.sort()
+    nose.tools.eq_(cds_list, CDS_HOSTNAMES)
+
+def test_09_readd_cds():
+    '''
+    add one of the CDSs again by using force
+    '''
+    # again choose a random CDS hostname from the list
+    cds = random.choice(CDS_HOSTNAMES)
+    status = RHUICLI.add(CONNECTION, "cds", cds, force=True, unsafe=True)
+    nose.tools.ok_(status, msg="unexpected %s readdition status: %s" % (cds, status))
+
+def test_10_list_cds():
+    '''
+    check if the CDSs are still tracked, and nothing extra has appeared
+    '''
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    # the readded CDS is now the last one in the list; the list may not be the same, sort it!
+    cds_list.sort()
+    nose.tools.eq_(cds_list, CDS_HOSTNAMES)
+
+def test_11_delete_cds_noforce():
+    '''
+    check if rhui refuses to delete the node when it's the only/last one and force isn't used
+    '''
+    # delete all but the first node (if there are more nodes to begin with)
+    if len(CDS_HOSTNAMES) > 1:
+        RHUICLI.delete(CONNECTION, "cds", CDS_HOSTNAMES[1:])
+    status = RHUICLI.delete(CONNECTION, "cds", [CDS_HOSTNAMES[0]])
+    nose.tools.ok_(not status, msg="unexpected deletion status: %s" % status)
+
+def test_12_list_cds():
+    '''
+    check if the last CDS really hasn't been deleted
+    '''
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    nose.tools.eq_(cds_list, [CDS_HOSTNAMES[0]])
+
+
+def test_13_delete_cds_force():
+    '''
+    delete the last CDS forcibly
+    '''
+    status = RHUICLI.delete(CONNECTION, "cds", [CDS_HOSTNAMES[0]], force=True)
+    nose.tools.ok_(status, msg="unexpected deletion status: %s" % status)
+
+def test_14_list_cds():
+    '''
+    check if the last CDS has been deleted
+    '''
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    nose.tools.eq_(cds_list, [])
+
+def test_15_add_bad_cds():
+    '''
+    try adding an incorrect CDS hostname, expect trouble and nothing added
+    '''
+    status = RHUICLI.add(CONNECTION, "cds", "foo" + CDS_HOSTNAMES[0])
+    nose.tools.ok_(not status, msg="unexpected addition status: %s" % status)
+    cds_list = RHUICLI.list(CONNECTION, "cds")
+    nose.tools.eq_(cds_list, [])
+
+# currently broken, see RHBZ#1409697
+# def test_16_delete_bad_cds():
+#     '''
+#     try deleting a non-existing CDS hostname, expect trouble
+#     '''
+#     status = RHUICLI.delete(CONNECTION, "cds", ["bar" + CDS_HOSTNAMES[0]], force=True)
+#     nose.tools.ok_(not status, msg="unexpected deletion status: %s" % status)
+
+def teardown():
+    '''
+    announce the end of the test run
+    '''
+    print("*** Finished running %s. *** " % basename(__file__))

--- a/tests/rhui3_tests/test_hap_cmd.py
+++ b/tests/rhui3_tests/test_hap_cmd.py
@@ -1,0 +1,147 @@
+'''HAProxy management tests for the CLI'''
+
+from os.path import basename
+
+import logging
+import nose
+import stitches
+
+from rhui3_tests_lib.rhui_cmd import RHUICLI
+from rhui3_tests_lib.rhuimanager import RHUIManager
+from rhui3_tests_lib.rhuimanager_instance import RHUIManagerInstance
+
+logging.basicConfig(level=logging.DEBUG)
+
+CONNECTION = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+
+HA_HOSTNAME = "hap01.example.com"
+
+def setup():
+    '''
+    announce the beginning of the test run
+    '''
+    print("*** Running %s: *** " % basename(__file__))
+
+def test_01_init():
+    '''
+    log in to RHUI
+    '''
+    RHUIManager.initial_run(CONNECTION)
+
+def test_02_list_hap():
+    '''
+    check if there are no HAProxy Load-balancers
+    '''
+    hap_list = RHUICLI.list(CONNECTION, "haproxy")
+    nose.tools.eq_(hap_list, [])
+
+def test_03_add_hap():
+    '''
+    add an HAProxy Load-balancer
+    '''
+    status = RHUICLI.add(CONNECTION, "haproxy", HA_HOSTNAME, unsafe=True)
+    nose.tools.ok_(status, msg="unexpected installation status: %s" % status)
+
+def test_04_list_hap():
+    '''
+    check if the HAProxy Load-balancer has been added
+    '''
+    hap_list = RHUICLI.list(CONNECTION, "haproxy")
+    nose.tools.eq_(hap_list, [HA_HOSTNAME])
+
+# currently broken, see RHBZ#1409693
+# def test_05_reinstall_hap():
+#     '''
+#     add the HAProxy Load-balancer again by reinstalling it
+#     '''
+#     status = RHUICLI.reinstall(CONNECTION, "haproxy", HA_HOSTNAME)
+#     nose.tools.ok_(status, msg="unexpected reinstallation status: %s" % status)
+#
+# def test_06_list_hap():
+#     '''
+#     check if the HAProxy Load-balancer is still tracked, and only once
+#     '''
+#     hap_list = RHUICLI.list(CONNECTION, "haproxy")
+#     nose.tools.eq_(hap_list, [HA_HOSTNAME])
+
+def test_07_readd_hap_noforce():
+    '''
+    check if rhui refuses to add the HAProxy Load-balancer again if no extra parameter is used
+    '''
+    status = RHUICLI.add(CONNECTION, "haproxy", HA_HOSTNAME, unsafe=True)
+    nose.tools.ok_(not status, msg="unexpected readdition status: %s" % status)
+
+def test_08_list_hap():
+    '''
+    check if nothing extra has been added
+    '''
+    hap_list = RHUICLI.list(CONNECTION, "haproxy")
+    nose.tools.eq_(hap_list, [HA_HOSTNAME])
+
+def test_09_readd_hap():
+    '''
+    add the HAProxy Load-balancer again by using force
+    '''
+    status = RHUICLI.add(CONNECTION, "haproxy", HA_HOSTNAME, force=True, unsafe=True)
+    nose.tools.ok_(status, msg="unexpected readdition status: %s" % status)
+
+def test_10_list_hap():
+    '''
+    check if the HAProxy Load-balancer is still tracked, and only once
+    '''
+    hap_list = RHUICLI.list(CONNECTION, "haproxy")
+    nose.tools.eq_(hap_list, [HA_HOSTNAME])
+
+# currently broken, see RHBZ#1409695
+# def test_11_delete_hap_noforce():
+#     '''
+#     check if rhui refuses to delete the node when it's the only/last one and force isn't used
+#     '''
+#     status = RHUICLI.delete(CONNECTION, "haproxy", [HA_HOSTNAME])
+#     nose.tools.ok_(not status, msg="unexpected deletion status: %s" % status)
+#
+# def test_12_list_hap():
+#     '''
+#     check if the HAProxy Load-balancer really hasn't been deleted
+#     '''
+#     hap_list = RHUICLI.list(CONNECTION, "haproxy")
+#     nose.tools.eq_(hap_list, [HA_HOSTNAME])
+#
+def test_13_delete_hap_force():
+    '''
+    delete the HAProxy Load-balancer forcibly - actually applying a workaround
+    '''
+    # remove the line below and uncomment the rest when RHBZ#1409695 is fixed
+    RHUIManagerInstance.delete(CONNECTION, "loadbalancers", [HA_HOSTNAME])
+    # status = RHUICLI.delete(CONNECTION, "haproxy", [HA_HOSTNAME], force=True)
+    # nose.tools.ok_(status, msg="unexpected deletion status: %s" % status)
+
+def test_14_list_hap():
+    '''
+    check if the HAProxy Load-balancer has been deleted
+    '''
+    hap_list = RHUICLI.list(CONNECTION, "haproxy")
+    nose.tools.eq_(hap_list, [])
+
+def test_15_add_bad_hap():
+    '''
+    try adding an incorrect HAProxy hostname, expect trouble and nothing added
+    '''
+    status = RHUICLI.add(CONNECTION, "haproxy", "foo" + HA_HOSTNAME)
+    nose.tools.ok_(not status, msg="unexpected addition status: %s" % status)
+    hap_list = RHUICLI.list(CONNECTION, "haproxy")
+    nose.tools.eq_(hap_list, [])
+
+# currently broken, see RHBZ#1409697
+# def test_16_delete_bad_hap():
+#     '''
+#     try deleting a non-existing HAProxy hostname, expect trouble
+#     '''
+#     status = RHUICLI.delete(CONNECTION, "haproxy", ["bar" + HA_HOSTNAME], force=True)
+#     nose.tools.ok_(not status, msg="unexpected deletion status: %s" % status)
+
+def teardown():
+    '''
+    announce the end of the test run
+    '''
+    print("*** Finished running %s. *** " % basename(__file__))

--- a/tests/rhui3_tests_lib/rhui_cmd.py
+++ b/tests/rhui3_tests_lib/rhui_cmd.py
@@ -1,0 +1,66 @@
+''' Methods to interact with the rhui command '''
+
+class RHUICLI(object):
+    '''
+    The 'rhui' command-line interface (shell commands to control CDS and HAProxy nodes).
+    '''
+    @staticmethod
+    def _validate_node_type(text):
+        '''
+        Check if the given text is a valid RHUI node type.
+        '''
+        ok_types = ["cds", "haproxy"]
+        if text not in ok_types:
+            raise ValueError("Unsupported node type: '%s'. Use one of: %s." % (text, ok_types))
+
+    @staticmethod
+    def list(connection, node_type):
+        '''
+        Return a list of CDS or HAProxy nodes (hostnames).
+        '''
+        RHUICLI._validate_node_type(node_type)
+        _, stdout, _ = connection.exec_command("rhui %s list" % node_type)
+        with stdout as output:
+            lines = output.read().decode()
+        nodes = [line.split(":")[1].strip() for line in lines.splitlines() if "Hostname:" in line]
+        return nodes
+
+    @staticmethod
+    def add(connection, node_type,
+            hostname, ssh_user="ec2-user", keyfile_path="/root/.ssh/id_rsa_rhua",
+            force=False, unsafe=False):
+        '''
+        Add a CDS or HAProxy node.
+        Return True if the command exited with 0, and False otherwise.
+        Note to the caller: Trust no one! Check for yourself if the node has really been added.
+        '''
+        RHUICLI._validate_node_type(node_type)
+        cmd = "rhui %s add %s %s %s" % (node_type, hostname, ssh_user, keyfile_path)
+        if force:
+            cmd += " -f"
+        if unsafe:
+            cmd += " -u"
+        return connection.recv_exit_status(cmd, timeout=300) == 0
+
+    @staticmethod
+    def reinstall(connection, node_type, hostname):
+        '''
+        Reinstall a CDS or HAProxy node.
+        Return True if the command exited with 0, and False otherwise.
+        '''
+        RHUICLI._validate_node_type(node_type)
+        cmd = "rhui %s reinstall %s" % (node_type, hostname)
+        return connection.recv_exit_status(cmd, timeout=120) == 0
+
+    @staticmethod
+    def delete(connection, node_type, hostnames, force=False):
+        '''
+        Reinstall one or more CDS or HAProxy nodes.
+        Return True if the command exited with 0, and False otherwise.
+        Note to the caller: Trust no one! Check for yourself if the nodes have really been deleted.
+        '''
+        RHUICLI._validate_node_type(node_type)
+        cmd = "rhui %s delete %s" % (node_type, " ".join(hostnames))
+        if force:
+            cmd += " -f"
+        return connection.recv_exit_status(cmd, timeout=180) == 0


### PR DESCRIPTION
Although the rhui (cds|haproxy) command has issues, it's useful and likely preferred by users who want to manage RHUI from the CLI or scripts. We didn't have test coverage for the command, though, so this commit adds it for those subcommands that work. It also contains commented-out tests for the subcommands that don't work, with references to the related bugs; these are some of the "Sri Lankan bugs". :)

Tested everywhere, as usual. Adds new content to the test plan; tested too.

```
*** Running test_hap_cmd.py: *** 
log in to RHUI ... ok
check if there are no HAProxy Load-balancers ... ok
add an HAProxy Load-balancer ... ok
check if the HAProxy Load-balancer has been added ... ok
check if rhui refuses to add the HAProxy Load-balancer again if no extra parameter is used ... ok
check if nothing extra has been added ... ok
add the HAProxy Load-balancer again by using force ... ok
check if the HAProxy Load-balancer is still tracked, and only once ... ok
delete the HAProxy Load-balancer forcibly - actually applying a workaround ... ok
check if the HAProxy Load-balancer has been deleted ... ok
try adding an incorrect HAProxy hostname, expect trouble and nothing added ... ok
*** Finished running test_hap_cmd.py. *** 
*** Running test_cds_cmd.py: *** 
log in to RHUI ... ok
check if there are no CDSs ... ok
add all known CDSs ... ok
check if the CDSes have been added ... ok
add one of the CDSs again by reinstalling it ... ok
check if the CDSs are still tracked, and nothing extra has appeared ... ok
check if rhui refuses to add a CDS again if no extra parameter is used ... ok
check if nothing extra has been added ... ok
add one of the CDSs again by using force ... ok
check if the CDSs are still tracked, and nothing extra has appeared ... ok
check if rhui refuses to delete the node when it's the only/last one and force isn't used ... ok
check if the last CDS really hasn't been deleted ... ok
delete the last CDS forcibly ... ok
check if the last CDS has been deleted ... ok
try adding an incorrect CDS hostname, expect trouble and nothing added ... ok
*** Finished running test_cds_cmd.py. *** 

----------------------------------------------------------------------
Ran 26 tests in 424.502s

OK
```