### PR TITLE
change Atomic node detection

### DIFF
--- a/deploy/roles/common/tasks/ntp.yml
+++ b/deploy/roles/common/tasks/ntp.yml
@@ -5,18 +5,18 @@
 - name: install ntp
   package: "pkg={{ item }} state=installed"
   with_items: [ntp, ntpdate]
-  when: ansible_env.SUDO_USER != "cloud-user"
+  when: not atomic | default(False)
   tags: ntp
 
 - name: configure ntp
   template: src=ntp.conf.j2 dest=/etc/ntp.conf
   notify:
   - restart ntpd
-  when: ansible_env.SUDO_USER != "cloud-user"
+  when: not atomic | default(False)
   tags: ntp
 
 - name: enable and run ntpd
   service: name=ntpd state=started enabled=yes
-  when: ansible_env.SUDO_USER != "cloud-user"
+  when: not atomic | default(False)
   tags: ntp
 

--- a/deploy/roles/common/tasks/vim.yml
+++ b/deploy/roles/common/tasks/vim.yml
@@ -7,5 +7,5 @@
   package:
     name: vim
     state: present
-  when: ansible_env.SUDO_USER != "cloud-user"
+  when: not atomic | default(False)
   tags: vim

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -678,7 +678,7 @@ try:
                 if instance["role"] == "ATOMIC_CLI":
                     f.write(str(instance['public_hostname']))
                     f.write(' ')
-                    f.write('ansible_ssh_user=cloud-user ansible_become=True ansible_ssh_private_key_file=')
+                    f.write('atomic=True ansible_ssh_user=cloud-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
                     f.write('\n')
         # test


### PR DESCRIPTION
Previously, if an operation wasn't supposed to be performed on Atomic hosts, the playbook checked if the `sudo` user wasn't `cloud-user`, which was typical of Atomic hosts. However, if `rhui3-automation` is used in OpenStack, these operations are skipped on all nodes because `cloud-user` is used on all OpenStack systems. This commit stores a boolean variable called `atomic` in the hosts configuration file among the properties of the Atomic client, if its creation is requested when running `create-cf-stack.py`, and skips the non-applicable operations if `atomic` isn't `True`.

Inspired by openshift/svt playbooks.

Tested successfully.