### PR TITLE
refresh RHEL 7 and Atomic AMIs to 7.6

### DIFF
--- a/ATOMICmapping.json
+++ b/ATOMICmapping.json
@@ -1,47 +1,47 @@
 {
     "us-east-1": {
-        "AMI": "ami-0a775b083271814a2"
+        "AMI": "ami-06ecdbacbca539c00"
     }, 
     "us-west-1": {
-        "AMI": "ami-036b774f6b3b851ac"
+        "AMI": "ami-0f9ead344b0103479"
     }, 
     "ap-northeast-2": {
-        "AMI": "ami-053b58d247976a40e"
+        "AMI": "ami-0e64177e457647495"
     }, 
     "ap-northeast-1": {
-        "AMI": "ami-00d51599378cca5aa"
+        "AMI": "ami-0f30cd6163f563d48"
     }, 
     "sa-east-1": {
-        "AMI": "ami-0e9d3ce49c39d7565"
+        "AMI": "ami-09b7807c76905847b"
     }, 
     "ap-southeast-1": {
-        "AMI": "ami-0bef83980d4215832"
+        "AMI": "ami-027d03bafbe584e75"
     }, 
     "ca-central-1": {
-        "AMI": "ami-035c84a74f983373b"
+        "AMI": "ami-0355621e4ab0be947"
     }, 
     "ap-southeast-2": {
-        "AMI": "ami-075ea797b06e7cd2e"
+        "AMI": "ami-0aa43690d8b95e5ae"
     }, 
     "us-west-2": {
-        "AMI": "ami-029d2fa68e76df419"
+        "AMI": "ami-0b6d8352d84c18784"
     }, 
     "us-east-2": {
-        "AMI": "ami-0f612c6ac7a4f64ac"
+        "AMI": "ami-0c852c4a0f51ee6c1"
     }, 
     "ap-south-1": {
-        "AMI": "ami-04dd025b3f831dc72"
+        "AMI": "ami-05ce988d7110abaae"
     }, 
     "eu-central-1": {
-        "AMI": "ami-08697ecb688e7f056"
+        "AMI": "ami-00bb3438538cf656d"
     }, 
     "eu-west-1": {
-        "AMI": "ami-0baf078600df861b3"
+        "AMI": "ami-05196a53815dfe45d"
     }, 
     "eu-west-2": {
-        "AMI": "ami-0a050676dcf403d31"
+        "AMI": "ami-0f8b3a22fcd116206"
     }, 
     "eu-west-3": {
-        "AMI": "ami-0b6d7488ff1688295"
+        "AMI": "ami-0d0bd7e5f8f1a704b"
     }
 }

--- a/RHEL7mapping.json
+++ b/RHEL7mapping.json
@@ -1,47 +1,47 @@
 {
     "us-east-1": {
-        "AMI": "ami-0456c465f72bd0c95"
+        "AMI": "ami-011b3ccf1bd6db744"
     }, 
     "us-west-1": {
-        "AMI": "ami-02574210e91c38419"
+        "AMI": "ami-0ec1ad91f200c15a8"
     }, 
     "ap-northeast-2": {
-        "AMI": "ami-031161cd3182e012a"
+        "AMI": "ami-07be38aae5985872f"
     }, 
     "ap-northeast-1": {
-        "AMI": "ami-0bf9ecb88f5719e17"
+        "AMI": "ami-08419d23bf91152e4"
     }, 
     "sa-east-1": {
-        "AMI": "ami-0a419d7f7b8b07b64"
+        "AMI": "ami-071ceb2e9e4b0ae06"
     }, 
     "ap-southeast-1": {
-        "AMI": "ami-0f44e46fa59e902b6"
+        "AMI": "ami-01b02e6dd3efebd61"
     }, 
     "ca-central-1": {
-        "AMI": "ami-e320ad87"
+        "AMI": "ami-0c896f6be8b26325e"
     }, 
     "ap-southeast-2": {
-        "AMI": "ami-0066ef2f9c72fad96"
+        "AMI": "ami-08d099ec55a5c5a16"
     }, 
     "us-west-2": {
-        "AMI": "ami-0e6bab6682ec471c0"
+        "AMI": "ami-036affea69a1101c9"
     }, 
     "us-east-2": {
-        "AMI": "ami-04268981d7c33264d"
+        "AMI": "ami-0b500ef59d8335eee"
     }, 
     "ap-south-1": {
-        "AMI": "ami-0c6ec6988a8df3acc"
+        "AMI": "ami-09a4d6a78af9e9a73"
     }, 
     "eu-central-1": {
-        "AMI": "ami-07d3f0705bebac978"
+        "AMI": "ami-00e37cffd3bb3ac8d"
     }, 
     "eu-west-1": {
-        "AMI": "ami-0c51cd02617947143"
+        "AMI": "ami-0e12cbde3e77cbb98"
     }, 
     "eu-west-2": {
-        "AMI": "ami-01f010afd559615b9"
+        "AMI": "ami-0b1eb35fb81061601"
     }, 
     "eu-west-3": {
-        "AMI": "ami-0a0167e3e2a1d1d9b"
+        "AMI": "ami-0da6335c8dff5d55a"
     }
 }


### PR DESCRIPTION
Using `RHEL-7.6_HVM_GA-20181017-x86_64-0-Hourly2-GP2` and `Atomic-7.6_HVM_GA-20181026-x86_64-0-Access2-GP2`.