### PR TITLE
add support for ARM64 client deployment and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Contents
 * `scripts/`: Scripts to simplify the deployment even more by creating a cloudformation stack with the individual RHUI 3 nodes and a hosts configuration file to use by Ansible.
 * `tests/`: Test suite (test cases and libraries) to verify the functionality of an installed RHUI 3 environment or check for potential regressions in updated RHUI 3 ISOs.
 * `hosts.cfg`: A template for the hosts configuration.
-* `{ATOMIC,RHEL{5,6,7,8}}mapping.json`: IDs of the latest Atomic and RHEL 5, 6, 7 & 8 AMIs. The deployment script uses this data.
+* `{ATOMIC,RHEL{5,6,7{,_arm64},8}}mapping.json`: IDs of the latest Atomic and RHEL 5, 6, 7 & 8 AMIs. The deployment script uses this data.
 
 Usage
 -----

--- a/RHEL7mapping_arm64.json
+++ b/RHEL7mapping_arm64.json
@@ -1,0 +1,47 @@
+{
+    "us-east-1": {
+        "AMI": "ami-0d20bcd0096e1645e"
+    }, 
+    "us-west-1": {
+        "AMI": "ami-0274b0723579b1820"
+    }, 
+    "ap-northeast-2": {
+        "AMI": ""
+    }, 
+    "ap-northeast-1": {
+        "AMI": ""
+    }, 
+    "sa-east-1": {
+        "AMI": ""
+    }, 
+    "ap-southeast-1": {
+        "AMI": ""
+    }, 
+    "ca-central-1": {
+        "AMI": ""
+    }, 
+    "ap-southeast-2": {
+        "AMI": ""
+    }, 
+    "us-west-2": {
+        "AMI": ""
+    }, 
+    "us-east-2": {
+        "AMI": ""
+    }, 
+    "ap-south-1": {
+        "AMI": ""
+    }, 
+    "eu-central-1": {
+        "AMI": "ami-05c68fc4ba99d22ce"
+    }, 
+    "eu-west-1": {
+        "AMI": "ami-0d1a2c70bad432aac"
+    }, 
+    "eu-west-2": {
+        "AMI": ""
+    }, 
+    "eu-west-3": {
+        "AMI": ""
+    }
+}

--- a/RHEL7mapping_arm64.json
+++ b/RHEL7mapping_arm64.json
@@ -1,9 +1,9 @@
 {
     "us-east-1": {
-        "AMI": "ami-0d20bcd0096e1645e"
+        "AMI": "ami-0e3688b4a755ad736"
     }, 
     "us-west-1": {
-        "AMI": "ami-0274b0723579b1820"
+        "AMI": ""
     }, 
     "ap-northeast-2": {
         "AMI": ""
@@ -24,19 +24,19 @@
         "AMI": ""
     }, 
     "us-west-2": {
-        "AMI": ""
+        "AMI": "ami-06efe10c4cab19e32"
     }, 
     "us-east-2": {
-        "AMI": ""
+        "AMI": "ami-0302c1ecc74930ba5"
     }, 
     "ap-south-1": {
         "AMI": ""
     }, 
     "eu-central-1": {
-        "AMI": "ami-05c68fc4ba99d22ce"
+        "AMI": ""
     }, 
     "eu-west-1": {
-        "AMI": "ami-0d1a2c70bad432aac"
+        "AMI": "ami-0b5171a7b859ff1b4"
     }, 
     "eu-west-2": {
         "AMI": ""

--- a/deploy/roles/cli/tasks/main.yml
+++ b/deploy/roles/cli/tasks/main.yml
@@ -8,7 +8,7 @@
   tags: cli
 
 - name: install docker if RHEL7
-  package: name=docker state=present enablerepo=rhui-REGION-rhel-server-extras
+  package: name=docker state=present enablerepo=*extras*
   with_indexed_items: "{{ groups['CLI'] }}"
   when: >
     "'CLI' in groups" and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,7 @@ Default configuration:
   * **--input-conf [name]** - the name of input conf file, `default = "/etc/rhui_ec2.yaml"`
   * **--output-conf [name]** - the name of output conf file, `default = "hosts_$RHELrelease_$iso.cfg"`
   * **--cli5/6/7/8 [number]** - number of CLI machines, `default = 0`
+  * **--cli7/8-arch [arch]** - CLI machines' architecture, `default = x86_64`
   * **--atomic-cli [number]** - number of ATOMIC CLI machines\*, `default = 0`
   * **--test** - if specified, TEST/MASTER machine, `default = 0`
   * **--region [name]** - `default = eu-west-1`
@@ -77,6 +78,10 @@ dnf -y update rh-amazon-rhui-client-beta
 dnf -y install python3
 alternatives --set python /usr/bin/python3
 ```
+
+If you specify a non-x86\_64 client architecture, a suitable instance type will be selected
+automatically. You may need to supply a VPC and a subnet ID with some instance types,
+e.g. with a1.large, which will be selected for arm64.
 
 Mutually exclusive options: 
 

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -56,7 +56,9 @@ argparser.add_argument('--iso', help='iso version', default="iso")
 argparser.add_argument('--cli5', help='number of RHEL5 clients', type=int, default=0)
 argparser.add_argument('--cli6', help='number of RHEL6 clients', type=int, default=0)
 argparser.add_argument('--cli7', help='number of RHEL7 clients', type=int, default=0)
+argparser.add_argument('--cli7-arch', help='RHEL 7 clients\' architecture', default='x86_64', metavar='ARCH')
 argparser.add_argument('--cli8', help='number of RHEL8 clients', type=int, default=0)
+argparser.add_argument('--cli8-arch', help='RHEL 8 clients\' architecture', default='x86_64', metavar='ARCH')
 argparser.add_argument('--cds', help='number of CDSes instances', type=int, default=1)
 argparser.add_argument('--dns', help='DNS', action='store_const', const=True, default=False)
 argparser.add_argument('--nfs', help='NFS', action='store_const', const=True, default=False)
@@ -339,16 +341,30 @@ else:
 
 # clients
 os_dict = {5: "RHEL5", 6: "RHEL6", 7: "RHEL7", 8: "RHEL8"}
+instance_types = {"arm64": "a1.large", "x86_64": "m3.large"}
 for i in (5, 6, 7, 8):
     num_cli_ver = args.__getattribute__("cli%i" % i)
     if num_cli_ver:
+        os = os_dict[i]
+        try:
+            cli_arch = args.__getattribute__("cli%i_arch" % i)
+        except AttributeError:
+            cli_arch = "x86_64"
+        try:
+            instance_type = instance_types[cli_arch]
+        except KeyError:
+            logging.error("Unknown architecture: %s" % cli_arch)
+            sys.exit(1)
+        if cli_arch == "x86_64":
+            image_id = {u'Fn::FindInMap': [os, {u'Ref': u'AWS::Region'}, u'AMI']}
+        else:
+            with open("RHEL%smapping_%s.json" % (i, cli_arch)) as mjson:
+               image_ids =  json.load(mjson)
+               image_id = image_ids[args.region]["AMI"]
         for j in range(1, num_cli_ver + 1):
-            os = os_dict[i]
             json_dict['Resources']["cli%inr%i" % (i, j)] = \
-                {u'Properties': {u'ImageId': {u'Fn::FindInMap': [os,
-                                                                   {u'Ref': u'AWS::Region'},
-                                                                   u'AMI']},
-                                   u'InstanceType': u'm3.large' if os == "RHEL5"  else u'm3.large',
+                {u'Properties': {u'ImageId': image_id,
+                                   u'InstanceType': instance_type,
                                    u'KeyName': {u'Ref': u'KeyName'},
                                    u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                    u'Tags': [{u'Key': u'Name',

--- a/scripts/get_amis_list.py
+++ b/scripts/get_amis_list.py
@@ -32,6 +32,10 @@ else:
     sys.stderr.write("Wrong parameters")
     sys.exit(1)
 
+ami_properties = args.rhel.split("-")
+if ami_properties[3] != "x86_64":
+    mapping = mapping.replace(".", "_%s." % ami_properties[3])
+
 regions = ["ap-northeast-1",
            "ap-northeast-2",
            "ap-south-1", 

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,7 @@ In addition, you need a ZIP file with the following files in the root of the arc
 * `rhcert.pem` — This must be a valid Red Hat content certificate allowing access to the following products:
   * _Red Hat Enterprise Linux for SAP (RHEL 6 Server) (RPMs) from RHUI_
   * _Red Hat Enterprise Linux for SAP (RHEL 7 Server) (RPMs) from RHUI_
+  * _Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 for ARM) (RPMs) from RHUI_
   * _Red Hat Enterprise Linux 8 for x86_64 - BaseOS Beta from RHUI (RPMs)_
 * `rhcert_atomic.pem` — This must be a valid Red Hat content certificate allowing access to the following products:
   * _Red Hat Enterprise Linux Atomic Host (Trees) from RHUI_

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -40,16 +40,21 @@ class TestClient(object):
         except IndexError:
             raise RuntimeError("No custom RPMs to test in %s" % CUSTOM_RPMS_DIR)
         self.cli_version = Util.get_rhel_version(CLI)["major"]
+        arch = Util.get_arch(CLI)
+        if arch == "arm64":
+            repos = "ARM_repos"
+        else:
+            repos = "yum_repos"
         with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:
-                self.yum_repo_name = doc["yum_repos"][self.cli_version]["name"]
-                self.yum_repo_version = doc["yum_repos"][self.cli_version]["version"]
-                self.yum_repo_kind = doc["yum_repos"][self.cli_version]["kind"]
-                self.yum_repo_path = doc["yum_repos"][self.cli_version]["path"]
-                self.test_package = doc["yum_repos"][self.cli_version]["test_package"]
+                self.yum_repo_name = doc[repos][self.cli_version]["name"]
+                self.yum_repo_version = doc[repos][self.cli_version]["version"]
+                self.yum_repo_kind = doc[repos][self.cli_version]["kind"]
+                self.yum_repo_path = doc[repos][self.cli_version]["path"]
+                self.test_package = doc[repos][self.cli_version]["test_package"]
             except KeyError as version:
-                raise nose.SkipTest("No test repo defined for RHEL %s" % version)
+                raise nose.SkipTest("No test repo defined for RHEL %s on %s" % (version, arch))
 
     @staticmethod
     def setup_class():

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -52,3 +52,10 @@ EUS_repos:
         name: "RHEL for SAP HANA (for RHEL 7 Server) Extended Update Support (RPMs) from RHUI (7.4-x86_64)"
         path: "content/eus/rhel/rhui/server/7/7.4/x86_64/sap-hana/os"
         test_package: "compat-sap-c++-7"
+ARM_repos:
+    7:
+        name: "Red Hat Satellite Tools 6.3 - Puppet 4 (for RHEL 7 for ARM) (RPMs) from RHUI"
+        version: "7Server-aarch64"
+        kind: "Yum"
+        path: "content/dist/rhel-alt/rhui/server/7/7Server/armv8-a/aarch64/sat-tools/6.3-puppet4/os"
+        test_package: "puppet-agent"

--- a/tests/rhui3_tests_lib/util.py
+++ b/tests/rhui3_tests_lib/util.py
@@ -152,6 +152,18 @@ class Util(object):
             return None
 
     @staticmethod
+    def get_arch(connection):
+        '''
+        get machine architecture; note that aarch64 is presented as arm64 for your convenience.
+        '''
+        _, stdout, _ = connection.exec_command("arch")
+        with stdout as output:
+            arch = output.read().decode().strip()
+        if arch == "aarch64":
+            arch = "arm64"
+        return arch
+
+    @staticmethod
     def wildcard(hostname):
         """ Hostname wildcard """
         hostname_particles = hostname.split('.')


### PR DESCRIPTION
This commit adds a mapping file with RHEL 7 ARM64 AMI IDs in the regions where such AMIs are currently available, updates the AMI list generation script to (re)generate such a list, updates the stack creation script to launch ARM64 clients, and adds support for ARM64 repos to the client management test case. A small RHEL 7 ARM64 repo with a single package with no special dependencies is also now available in the YAML file with test repos.

Note that you need to specify VPC and subnet IDs to be able to launch an ARM64 client; EC2 classic can't be used with the flavor that ARM64 is based on. Additionally, you will need to fetch and copy the `rh-amazon-rhui-client-arm` package to the client before running the deployment playbook as the AMI has no repos by default.