### PR TITLE
require the RHEL AMI argument, use no default

### DIFF
--- a/scripts/get_amis_list.py
+++ b/scripts/get_amis_list.py
@@ -14,9 +14,13 @@ if subprocess.call("aws configure get aws_access_key_id &> /dev/null", shell=Tru
     sys.exit(1)
 
 argparser = argparse.ArgumentParser(description='Get list of AMIs')
-argparser.add_argument('--rhel', help='Description of the ami (f.e. RHEL-7.5_HVM_GA-20180322-x86_64-1-Hourly2-GP2)', default="RHEL-7.5_HVM_GA-20180322-x86_64-1-Hourly2-GP2")
+argparser.add_argument('rhel', help='Description of the ami (f.e. RHEL-7.5_HVM_GA-20180322-x86_64-1-Hourly2-GP2)', metavar='AMI', nargs='?')
 
 args = argparser.parse_args()
+
+if not args.rhel:
+    argparser.print_help()
+    sys.exit(1)
 
 if args.rhel.startswith("RHEL-8"):
     mapping = "RHEL8mapping.json"


### PR DESCRIPTION
I could use `require=True`, but its use is discouraged as optional arguments should really be optional. So I turned the `--rhel` optional argument to the `rhel` positional argument first. That itself wouldn't print the help message if no AMI is specified, though, so I made additional necessary changes. Result:

```
$ ./scripts/get_amis_list.py
usage: get_amis_list.py [-h] [AMI]

Get list of AMIs

positional arguments:
  AMI         Description of the ami (f.e.
              RHEL-7.5_HVM_GA-20180322-x86_64-1-Hourly2-GP2)

optional arguments:
  -h, --help  show this help message and exit
```