### PR TITLE
simplify test execution and reporting

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -135,6 +135,14 @@
   when: rhaccount is defined
   tags: tests
 
-- name: run tests suite
-  shell: PYTHONUNBUFFERED=1 nosetests -vs /usr/share/rhui3_tests_lib/rhui3_tests &>>/tmp/rhui3test.log
+- name: run tests
+  command: "rhuitests {{ tests }} quiet"
+  register: testreport
+  when: tests is defined
+  tags: run_tests
+
+- name: print test report locations
+  debug:
+    var: testreport.stdout_lines
+  when: tests is defined
   tags: run_tests

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ In addition, you need a ZIP file with the following files in the root of the arc
 * `rhui-rpm-upload-trial-1-1.noarch.rpm` — This package will also be uploaded to a custom repository. It must be signed with the RHUI QE GPG key.
 * `rhui-rpm-upload-tryout-1-1.noarch.rpm` — This package will also be uploaded to a custom repository. It must be signed with a key different from RHUI QE.
 * `test_gpg_key` — This is the RHUI QE public GPG key (0x9F6E93A2).
-* `\*.tar` — These must be tarballs containing some packages and their `updateinfo.xml.gz` files. The contents will be used for updateinfo testing. Exact names are to be specified in `rhui3_tests/tested_repos.yaml`.
+* `ANYTHING.tar` — These must be tarballs containing some packages and their `updateinfo.xml.gz` files. The contents will be used for updateinfo testing. Exact names are to be specified in `rhui3_tests/tested_repos.yaml`.
 
 Lastly, in order for the subscription test to be able to run, you need a file with valid Red Hat credentials allowing access to RHUI. The file must look like this:
 
@@ -55,33 +55,36 @@ Enter an appropriate encryption password when prompted.
 
 Usage
 --------
-You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instances in the `[CLI]` and `[ATOMIC_CLI]` sections of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the `--extra-vars` switch with the required ZIP file as a parameter of the `extra-files` option and also the required credentials file as a parameter of the `rhaccount` option. If the credentials file is encrypted, you will have to either provide the encryption password interactively or store it in a separate file (however, if someone reads that file, they will be able to read your Red Hat credentials, too, so be careful where you store the file).
+You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instances in the `[CLI]` and `[ATOMIC_CLI]` sections of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the `--extra-vars` switch with the required ZIP file as a parameter of the `extra-files` option, the required credentials file as a parameter of the `rhaccount` option, and the `tests` variable with `all`, `client`, or a test name as its parameter; the test name is the part of the file name in the `rhui3_tests` directory between `test` and the extension. If the credentials file is encrypted, you will have to either provide the encryption password interactively or store it in a separate file (however, if someone reads that file, they will be able to read your Red Hat credentials, too, so be careful where you store the file).
 
 To install _and run the whole test suite_ as part of the initial deployment or after a completed deployment, use either the following command if you would like to enter the encryption password by hand:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh" --ask-vault-pass`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh tests=all" --ask-vault-pass`
 
-Or the following command if you have stored the encryption password in a separate file:
+Or the following command if you have stored the encryption password in a separate file and you only want to run the client tests:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh" --vault-password-file ~/Path/To/The/File/With/The/password`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh tests=client" --vault-password-file ~/Path/To/The/File/With/The/password`
 
 Beware, regardless of the command you use, the credentials file will be stored on the RHUA node, _unencrypted_, as `/tmp/extra_rhui_files/rhaccount.sh`.
 
 Provide any other optional variables described in the RHUI deployment Readme as needed.
 
-Note that it can take a few hours for all the test cases to run. If you only want to install the test machine, add `--skip-tags run_tests` on the command line.
+Note that it can take a few hours for all the test cases to run. If you only want to install the test machine, do not use the `tests` parameter among the extra variables on the command line.
 
-The test cases will be installed in the `/usr/share/rhui3_tests_lib/rhui3_tests/` directory and the libraries in the `/usr/lib/python*/site-packages/rhui3_tests_lib/` directory on the TEST machine. The output of the tests will be stored in `/tmp/rhui3test.log` on the TEST machine.
+The test cases will be installed in the `/usr/share/rhui3_tests_lib/rhui3_tests/` directory and the libraries in the `/usr/lib/pythonVERSION/site-packages/rhui3_tests_lib/` directory on the TEST machine. The output of the tests will be stored in a local report file, which will also be available on the web. The file name and the URL will be printed by Ansible.
 
-If you now want to run the whole test suite, or if you want to run it again, you have two options. Either use _Ansible_ again as follows:
+If you now want to run the tests, or if you want to run them again, you have two options. Either use _Ansible_ again as follows:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --tags run_tests`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --tags run_tests --extra-vars tests=all`
 
-Or log in to the TEST machine, become root, and use _nose_ as follows:
+Or log in to the TEST machine, become root, and run:
 
-`nosetests -vs /usr/share/rhui3_tests_lib/rhui3-tests`
+`rhuitests all`
 
-To run only a single test case, or a subset of the available test cases, specify the test case(s) as the corresponding `test_XYZ.py` file name(s) on the `nosetests -vs` command line instead of the directory containing all the test cases. For example:
+Alternatively, you can run only the client tests while logged in to the system:
 
-`nosetests -vs /usr/share/rhui3_tests_lib/rhui3-tests/test_client_management.py`
+`rhuitests client`
 
+Lastly, to run only a single test case, e.g. `test_XYZ.py`:
+
+`rhuitests XYZ`

--- a/tests/rhui3_tests/test_eus_cmd.py
+++ b/tests/rhui3_tests/test_eus_cmd.py
@@ -144,14 +144,13 @@ class TestEUSCLI(object):
         check if Yum is now working with the EUS URL
         '''
         # the name of the test package contains plus signs, which must be escaped in REs
-        # also, the URL can be .../os/...NVR or .../os//...NVR, so let's tolerate the extra slash
+        # in modern pulp-rpm versions, packages are in .../Packages/<first letter (lowercase)>/
+        # also, the URL can be .../os/...NVR or .../os//...NVR, so let's tolerate both cases
         test_package_escaped = re.escape(self.test_package)
-        # packages are now (early 2019) in .../Packages/<first letter>/
-        first_letter = self.test_package[0]
         Expect.ping_pong(CLI,
                          "yumdownloader --url %s" % test_package_escaped,
-                         "https://cds.example.com/pulp/repos/%s//?Packages/%s/%s" % \
-                         (self.repo_path, first_letter, test_package_escaped))
+                         "https://cds.example.com/pulp/repos/%s/.*/%s" % \
+                         (self.repo_path, test_package_escaped))
 
     def test_12_install_test_rpm(self):
         '''

--- a/tests/rhui3_tests_lib/rhuimanager_instance.py
+++ b/tests/rhui3_tests_lib/rhuimanager_instance.py
@@ -60,7 +60,10 @@ class RHUIManagerInstance(object):
         if state == 2:
             # cds or haproxy of the same hostname is already being tracked
             if not update:
-                # but we don't wish to update its config: raise
+                # but we don't wish to update its config: say no, quit rhui-manager, and raise
+                # an exception
+                Expect.enter(connection, "n")
+                RHUIManager.quit(connection)
                 raise InstanceAlreadyExistsError("%s already tracked but update wasn't required" % \
                                                  hostname)
             else:

--- a/tests/scripts/report_testrun.sh
+++ b/tests/scripts/report_testrun.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-#This is dummy script expected to report logs from test runs

--- a/tests/scripts/rhuireport
+++ b/tests/scripts/rhuireport
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Upload the given report file to the web server on the RHUA so it can be fetched from there easily.
+# (That's possible thanks to the fact that Apache on the RHUA also listens on port 80 but there's
+# no content there.)
+
+if ! [[ $1 ]]; then
+    echo "No report given. Please run $(basename $0) report_file."
+    exit 1
+fi
+
+if ! test -f $1; then
+    echo "$1 is not a valid file name."
+    exit 1
+fi
+
+identity=~/.ssh/id_rsa_test
+rhua=rhua.example.com
+# if in AWS, get the public RHUA hostname using the instance metadata
+# otherwise, default to the constant, which may or may not be usable, but at least we tried
+rhua_public_hostname=$(ssh -i $identity -o StrictHostKeyChecking=no -q $rhua \
+    "curl -s http://169.254.169.254/latest/meta-data/public-hostname" || echo $rhua)
+
+scp -i $identity -q $1 $rhua:/var/www/html
+
+if [ $? -eq 0 ]; then
+    echo "report saved as: http://$rhua_public_hostname/$(basename $1)"
+else
+    echo "report could not be made available on the web"
+    exit 1
+fi

--- a/tests/scripts/rhuitestcleanup
+++ b/tests/scripts/rhuitestcleanup
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+'''Remove certificates and unregister CDS and HAProxy nodes. '''
+
+import stitches
+
+from rhui3_tests_lib.rhuimanager import RHUIManager
+from rhui3_tests_lib.rhuimanager_instance import RHUIManagerInstance, NoSuchInstance
+
+CONNECTION = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+CDS = "cds01.example.com"
+HA = "hap01.example.com"
+
+print("Removing entitlement certificates.")
+RHUIManager.remove_rh_certs(CONNECTION)
+
+print("Unregistering the CDS.")
+try:
+    RHUIManagerInstance.delete(CONNECTION, "cds", [CDS])
+except NoSuchInstance:
+    print("Not registered, never mind.")
+
+print("Unregistering the HAProxy load balancer.")
+try:
+    RHUIManagerInstance.delete(CONNECTION, "loadbalancers", [HA])
+except NoSuchInstance:
+    print("Not registered, never mind.")

--- a/tests/scripts/rhuitests
+++ b/tests/scripts/rhuitests
@@ -68,6 +68,7 @@ if [[ $2 != quiet ]]; then
 fi
 
 if [[ $1 == client ]]; then
+    export RHUISKIPSETUP=1
     if [[ $2 == quiet ]]; then
         rhuitestsetup > /dev/null
         setup_ecode=$?
@@ -88,7 +89,6 @@ fi
 
 output=/tmp/$(basename $0)_$1_output_$(date +%F-%T).txt
 identity=~/.ssh/id_rsa_test
-export RHUISKIPSETUP=1
 export PYTHONUNBUFFERED=1
 
 if [[ $1 == all ]]; then
@@ -97,7 +97,7 @@ if [[ $1 == all ]]; then
         result=$?
     else
         nosetests -vs 2>&1 | tee $output
-        result=$?
+        result=${PIPESTATUS[0]}
     fi
 elif [[ $1 == client ]]; then
     result=0
@@ -109,15 +109,16 @@ elif [[ $1 == client ]]; then
             ((result++))
             continue
         fi
-        echo "Using $client, ie. $client_info" >> $output
         export RHUICLI=$client
         if [[ $2 == quiet ]]; then
+            echo "Using $client, ie. $client_info" >> $output
             nosetests -vs $tests &>> $output
             ((result+=$?))
         else
+            echo "Using $client, ie. $client_info" | tee -a $output
             nosetests -vs $tests 2>&1 | tee -a $output
+            ((result+=${PIPESTATUS[0]}))
             echo
-            ((result+=$?))
         fi
     done
 elif [[ $1 ]]; then
@@ -126,7 +127,7 @@ elif [[ $1 ]]; then
         result=$?
     else
         nosetests -vs $test 2>&1 | tee $output
-        result=$?
+        result=${PIPESTATUS[0]}
     fi
 fi
 

--- a/tests/scripts/rhuitests
+++ b/tests/scripts/rhuitests
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Find and run RHUI tests: all or those that involve a client machine.
+# Client tests will run on all cliN.example.com machines found in /etc/hosts,
+# unless a specific hostname is defined in the RHUICLI environment variable.
+
+tests_dir=/usr/share/rhui3_tests_lib/rhui3_tests
+if ! test -d $tests_dir; then
+  echo "Cannot proceed: $tests_dir does not exist."
+  exit 1
+fi
+cd $tests_dir
+if [[ $1 == all ]]; then
+    contents=$(ls)
+    if ! [[ $contents ]]; then
+        echo "No test cases found. The installation of rhui3_tests_lib is broken."
+        exit 1
+    fi
+    tests_pretty="all tests"
+elif [[ $1 == client ]]; then
+    tests=$(grep -l RHUICLI=hostname test_*.py)
+    if [ $? -ne 0 ]; then
+        echo "No client test cases found. The installation of rhui3_tests_lib is broken."
+        exit 1
+    fi
+    tests_list=(`echo $tests`)
+    tests_pretty=${tests_list[0]}
+    for ((i=1; i<${#tests_list[*]}; i++)); do
+        tests_pretty="$tests_pretty, ${tests_list[$i]}"
+    done
+
+    if [[ $RHUICLI ]]; then
+        clients=$RHUICLI
+        clients_pretty=$RHUICLI
+    else
+        clients=$(egrep -o 'cli[0-9]+\.example\.com' /etc/hosts)
+        if [ $? -ne 0 ]; then
+            echo "No clients found. Add at least one."
+            exit 1
+        fi
+        clients_list=(`echo $clients`)
+        clients_pretty=${clients_list[0]}
+        for ((i=1; i<${#clients_list[*]}; i++)); do
+            clients_pretty="$clients_pretty, ${clients_list[$i]}"
+        done
+    fi
+elif [[ $1 ]]; then
+    if test -f test_$1.py; then
+        test=test_$1.py
+        tests_pretty=$test
+    else
+        echo "$PWD/test_$1.py does not exist. Check the spelling, and make sure the rhui3_tests_lib installation is all right."
+        exit 1
+    fi
+else
+    echo "Usage: $(basename $0) all|client|NAME [quiet]"
+    exit 1
+fi
+
+if [[ $2 != quiet ]]; then
+    echo '*** RHUI Tests ***'
+    echo -n "Plan: run $tests_pretty"
+    if [[ $1 == client ]]; then
+        echo " on $clients_pretty."
+    else
+        echo
+    fi
+    echo
+fi
+
+if [[ $1 == client ]]; then
+    if [[ $2 == quiet ]]; then
+        rhuitestsetup > /dev/null
+        setup_ecode=$?
+    else
+        echo '*** Setup ***'
+        rhuitestsetup
+        setup_ecode=$?
+    fi
+    if [ $setup_ecode -ne 0 ]; then
+        echo "Cannot proceed: setup failed."
+        exit 1
+    fi
+    if [[ $2 != quiet ]]; then
+        echo '*** Done ***'
+        echo
+    fi
+fi
+
+output=/tmp/$(basename $0)_$1_output_$(date +%F-%T).txt
+identity=~/.ssh/id_rsa_test
+export RHUISKIPSETUP=1
+export PYTHONUNBUFFERED=1
+
+if [[ $1 == all ]]; then
+    if [[ $2 == quiet ]]; then
+        nosetests -vs &> $output
+        result=$?
+    else
+        nosetests -vs 2>&1 | tee $output
+        result=$?
+    fi
+elif [[ $1 == client ]]; then
+    result=0
+    for client in $clients; do
+        client_info=$(ssh -i $identity -o StrictHostKeyChecking=no -q $client \
+            "echo OS: \$(< /etc/redhat-release), arch: \$(arch).")
+        if [ $? -ne 0 ]; then
+            echo "Skipping $client, which is unreachable."
+            ((result++))
+            continue
+        fi
+        echo "Using $client, ie. $client_info" >> $output
+        export RHUICLI=$client
+        if [[ $2 == quiet ]]; then
+            nosetests -vs $tests &>> $output
+            ((result+=$?))
+        else
+            nosetests -vs $tests 2>&1 | tee -a $output
+            echo
+            ((result+=$?))
+        fi
+    done
+elif [[ $1 ]]; then
+    if [[ $2 == quiet ]]; then
+        nosetests -vs $test &> $output
+        result=$?
+    else
+        nosetests -vs $test 2>&1 | tee $output
+        result=$?
+    fi
+fi
+
+if [ $result -gt 0 ]; then
+    echo 'An issue occurred!'
+fi
+
+if test -s $output; then
+    echo "report saved as: $output"
+    rhuireport $output
+else
+    echo 'No output captured!'
+fi
+
+if [[ $1 == client ]]; then
+    if [[ $2 == quiet ]]; then
+        rhuitestcleanup > /dev/null
+    else
+        echo
+        echo '*** Cleanup ***'
+        rhuitestcleanup
+        echo '*** Done ***'
+        echo '*** End of RHUI Tests ***'
+    fi
+fi

--- a/tests/scripts/rhuitestsetup
+++ b/tests/scripts/rhuitestsetup
@@ -1,0 +1,30 @@
+#!/usr/bin/python
+'''Log in to RHUI, upload a certificate, and add a CDS and a HAProxy node. '''
+
+import stitches
+
+from rhui3_tests_lib.rhuimanager import RHUIManager
+from rhui3_tests_lib.rhuimanager_entitlement import RHUIManagerEntitlements
+from rhui3_tests_lib.rhuimanager_instance import RHUIManagerInstance, InstanceAlreadyExistsError
+
+CONNECTION = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
+CDS = "cds01.example.com"
+HA = "hap01.example.com"
+
+print("Logging in to RHUI.")
+RHUIManager.initial_run(CONNECTION)
+
+print("Uploading an entitlement certificate.")
+RHUIManagerEntitlements.upload_rh_certificate(CONNECTION)
+
+print("Adding a CDS (%s)." % CDS)
+try:
+    RHUIManagerInstance.add_instance(CONNECTION, "cds", CDS)
+except InstanceAlreadyExistsError:
+    print("Already added, never mind.")
+
+print("Adding an HAProxy load balancer (%s)." % HA)
+try:
+    RHUIManagerInstance.add_instance(CONNECTION, "loadbalancers", HA)
+except InstanceAlreadyExistsError:
+    print("Already added, never mind.")

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -46,5 +46,5 @@ setup(name='rhui3_tests_lib',
           'Intended Audience :: Developers',
           'Development Status :: 5 - Production/Stable'
       ],
-      scripts=glob('scripts/*.py') + glob('scripts/*.sh')
+      scripts=glob('scripts/*')
      )


### PR DESCRIPTION
This commit adds the following features:

* set up / unregister CDS & HAProxy & upload the CCSP cert using a command. If you then export a special environment variable, client tests will skip this setup/cleanup. As a result, if you're running multiple client tests, they don't have to do this setup/cleanup on their own (n-of-tests times), so a lot of time is saved.
* run all tests, or client tests, or a specific test using a command with the appropriate parameter. This command can be verbose or quiet, and it stores the output in a file whose name contains the test type and a timestamp.
* a script to report the test output to a location reachable by HTTP for further convenience. The above-mentioned command that runs tests calls this script automatically when it's done.
* more fine-grained test execution as part of the Ansible playbook: use `tests=[all|client|NAME]` among the extra vars to run the desired test(s) at the end of the deployment (default = don't run any tests, just deploy everything). Or use that together with `--tags run_tests` to only run the test(s) on an already deployed RHUI. A link to the test output is printed by Ansible for the utmost convenience.
