### PR TITLE
set a usable Python interpreter on RHEL-8 clients, update their conf RPM

### DIFF
--- a/deploy/roles/common/tasks/main.yml
+++ b/deploy/roles/common/tasks/main.yml
@@ -4,7 +4,7 @@
 # set up custom DNS if requested
 # disable (or remove) cloud-init
 # install vim
-- include: upgrade_all_pkg.yml
+- include: upgrade.yml
 - include: ntp.yml
 - include: hosts.yml
 - include: dns_override.yml

--- a/deploy/roles/common/tasks/upgrade.yml
+++ b/deploy/roles/common/tasks/upgrade.yml
@@ -1,0 +1,12 @@
+# file: roles/common/upgrade.yml
+# update packages prior to rhui installation: the RHEL-8 Beta client configuration and/or all
+
+- name: upgrade rh-amazon-rhui-client-beta on RHEL 8
+  package: name=rh-amazon-rhui-client-beta state=latest update_cache=yes
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
+  tags: upgrade_beta_client_pkg
+
+- name: upgrade all packages
+  package: name=* state=latest update_cache=yes
+  when:  upgrade_all_pkg is defined and upgrade_all_pkg | bool
+  tags: upgrade_all_pkg

--- a/deploy/roles/common/tasks/upgrade_all_pkg.yml
+++ b/deploy/roles/common/tasks/upgrade_all_pkg.yml
@@ -1,7 +1,0 @@
-# file: roles/common/upgrade_all_pkg.yml
-# update all paclages prior to rhui installation
-
-- name: upgrade all packages
-  package: name=* state=latest update_cache=yes
-  when:  upgrade_all_pkg is defined and upgrade_all_pkg | bool
-  tags: upgrade_all_pkg

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -68,13 +68,11 @@ with the RHEL-5 client hostname and other data commented out so that it is all v
 ignored by `ansible-playbook`. Other than that, you are free to use the launched RHEL-5 client any
 way you want, just be sure to log in as root directly.
 
-Note that RHEL-8 AMIs are missing the unversioned `python` command as well as a working Python
-installation, which Ansible expects on managed hosts. Therefore, if you create a stack with a RHEL-8
-client machine, make sure Python is installed and configured there before you run the deployment
-playbook:
+Note that RHEL-8 AMIs are missing the unversioned `python` command. This does not affect
+the deployment because the _platform Python_ is used with RHEL-8 hosts. However, if you want to use
+the `(/usr/bin/)python` executable on a RHEL-8 client, run the following commands there beforehand:
 
 ```
-dnf -y update rh-amazon-rhui-client-beta
 dnf -y install python3
 alternatives --set python /usr/bin/python3
 ```

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -700,6 +700,10 @@ try:
                         f.write('ansible_ssh_user=ec2-user ansible_become=True ')
                     f.write('ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    # https://www.ansible.com/blog/integrating-ansible-and-red-hat-enterprise-linux-8-beta
+                    # remove when Ansible 2.8 is released
+                    if instance["OS"] == "RHEL8":
+                        f.write(' ansible_python_interpreter=/usr/libexec/platform-python')
                     f.write('\n')
         # atomic_cli
         if args.atomic_cli:


### PR DESCRIPTION
This commit eliminates the need for the three steps that used to be necessary on RHEL-8 clients before running the deployment playbook.