### PR TITLE
launch client machines for all architectures easily

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,8 +50,8 @@ Default configuration:
   * **--haproxy [number]** - number of HAProxies, `default = 1`
   * **--input-conf [name]** - the name of input conf file, `default = "/etc/rhui_ec2.yaml"`
   * **--output-conf [name]** - the name of output conf file, `default = "hosts_$RHELrelease_$iso.cfg"`
-  * **--cli5/6/7/8 [number]** - number of CLI machines, `default = 0`
-  * **--cli7/8-arch [arch]** - CLI machines' architecture, `default = x86_64`
+  * **--cli5/6/7/8 [number]** - number of CLI machines, `default = 0`, use `-1` to get machines for all architectures (one machine per architecture)
+  * **--cli7/8-arch [arch]** - CLI machines' architectures (comma-separated list), `default = x86_64 for all of them`, `cli`_N_ set to `-1` will populate the list with all architectures automatically, so this parameter is unnecessary then
   * **--atomic-cli [number]** - number of ATOMIC CLI machines\*, `default = 0`
   * **--test** - if specified, TEST/MASTER machine, `default = 0`
   * **--region [name]** - `default = eu-west-1`
@@ -121,6 +121,10 @@ There is an extra 100 GB volume attached to each CDS machine.
 * `scripts/create-cf-stack.py --rhua RHEL7 --dns --cds 2 --cli6 1 --cli7 1 --input-conf /etc/rhui_amazon.yaml --output-conf my_new_hosts_config_file.cfg --iso 20160809`
   * RHEL7 NFS configuration
   * 1xRHUA=NFS, 1xDNS, 2xCDS, 1xCLI6, 1xCLI7, 1xHAProxy
+* `scripts/create-cf-stack.py --input-conf rhui_ec2.yaml --rhua RHEL7 --iso rhel8clients --cli8 -1 --test --vpcid vpc-012345678 --subnetid subnet-89abcdef`
+  * RHEL7 NFS configuration
+  * custom input configuration file in the current working directory
+  * 1xRHUA=NFS=DNS, 1xCDS, 1xHAProxy, 2xCLI8 (x86_64 and ARM64), 1xTEST, custom VPC and subnet (needed by the `a1` instance type used with ARM64)
 
 #### Input configuration file
 

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -48,6 +48,7 @@ class SyncSSHClient(SSHClient):
         chan.close()
         return status
 
+instance_types = {"arm64": "a1.large", "x86_64": "m3.large"}
 
 argparser = argparse.ArgumentParser(description='Create CloudFormation stack')
 argparser.add_argument('--rhua', help='RHEL version for RHUI setup (RHEL6, RHEL7)', default="RHEL6")
@@ -148,6 +149,13 @@ if args.atomic_cli:
     if args.rhua != "RHEL7":
         logging.error("ATOMIC clients need 'RHEL7' for RHUI setup")
         sys.exit(1)
+
+if args.cli7 == -1:
+    args.cli7 = len(instance_types)
+    args.cli7_arch = ",".join(instance_types.keys())
+if args.cli8 == -1:
+    args.cli8 = len(instance_types)
+    args.cli8_arch = ",".join(instance_types.keys())
 
 json_dict['Description'] = 'RHUI with %s CDSes' % args.cds
 json_dict['Description'] += " %s HAProxy" % args.haproxy
@@ -341,7 +349,6 @@ else:
 
 # clients
 os_dict = {5: "RHEL5", 6: "RHEL6", 7: "RHEL7", 8: "RHEL8"}
-instance_types = {"arm64": "a1.large", "x86_64": "m3.large"}
 for i in (5, 6, 7, 8):
     num_cli_ver = args.__getattribute__("cli%i" % i)
     if num_cli_ver:


### PR DESCRIPTION
Let's simplify the creation of a stack with client machines running on all supported architectures:

Before: `--cli8 2 --cli8-arch x86_64,arm64`
After: `--cli8 -1`

Readme updated.