### PR TITLE
provide enough disk space in an NFS setup and for MongoDB

### DIFF
--- a/deploy/roles/nfs/tasks/main.yml
+++ b/deploy/roles/nfs/tasks/main.yml
@@ -12,8 +12,22 @@
   package: name=nfs-utils state=present
   tags: nfs
 
-- name: create volume
+- name: create storage volume directory
   file: path=/export state=directory
+  tags: nfs
+
+- name: format storage volume device
+  filesystem:
+    fstype: xfs
+    dev: /dev/xvdb
+  tags: nfs
+
+- name: mount storage volume filesystem
+  mount:
+    path: /export
+    src: /dev/xvdb
+    fstype: xfs
+    state: mounted
   tags: nfs
 
 - name: start rpcbind service

--- a/deploy/roles/rhua/tasks/main.yml
+++ b/deploy/roles/rhua/tasks/main.yml
@@ -6,6 +6,7 @@
   tags: rhua
 
 - include: ssh.yml
+- include: mongodb.yml
 
 - name: install rhui-installer
   package: name=rhui-installer state=present

--- a/deploy/roles/rhua/tasks/mongodb.yml
+++ b/deploy/roles/rhua/tasks/mongodb.yml
@@ -1,0 +1,17 @@
+---
+# file: roles/rhua/tasks/mongodb.yml
+# format and mount a separate volume for MongoDB
+
+- name: format MongoDB volume device
+  filesystem:
+    fstype: xfs
+    dev: /dev/xvdm
+  tags: rhua
+
+- name: mount MongoDB volume filesystem
+  mount:
+    path: /var/lib/mongodb
+    src: /dev/xvdm
+    fstype: xfs
+    state: mounted
+  tags: rhua

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -283,6 +283,8 @@ json_dict['Resources'] = \
                         u'Type': u'AWS::EC2::SecurityGroup'}}
 
 # nfs == rhua
+# add a 100 GB volume for RHUI repos if using NFS
+# add a 50 GB volume for MongoDB either way; MongoDB can be greedy
 if (fs_type == "rhua"):
     json_dict['Resources']["rhua"] = \
      {u'Properties': {u'ImageId': {u'Fn::FindInMap': [args.rhua, {u'Ref': u'AWS::Region'}, u'AMI']},
@@ -293,6 +295,10 @@ if (fs_type == "rhua"):
                                             {
                                               "DeviceName" : "/dev/sdb",
                                               "Ebs" : {"VolumeSize" : "100"}
+                                            },
+                                            {
+                                              "DeviceName" : "/dev/sdm",
+                                              "Ebs" : {"VolumeSize" : "50"}
                                             },
                                  ],
                                u'Tags': [{u'Key': u'Name',
@@ -307,6 +313,12 @@ else:
                                u'InstanceType': args.r3 and u'r3.xlarge' or u'm3.large',
                                u'KeyName': {u'Ref': u'KeyName'},
                                u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
+                                 u'BlockDeviceMappings' : [
+                                            {
+                                              "DeviceName" : "/dev/sdm",
+                                              "Ebs" : {"VolumeSize" : "50"}
+                                            },
+                                 ],
                                u'Tags': [{u'Key': u'Name',
                                           u'Value': {u'Fn::Join': [u'_', [ec2_name, args.rhua, fs_type_f, args.iso, u'rhua']]}},
                                          {u'Key': u'Role', u'Value': u'RHUA'},


### PR DESCRIPTION
Two changes:

1. Previously, the stack creation script attached `/dev/sdb` (in fact `xvdb`) on the NFS server, but the volume was never used in the deployment playbook. It is now properly formatted and mounted at `/export` so that there's enough disk space for packages in RHUI repos.
1. It turns out that MongoDB files can easily consume more disk space than the default setup with a 10 GB root partition provides, even if the packages are kept elsewhere. This commit attaches a 50 GB volume in the stack creation script, and formats and mounts it at `/var/lib/mongodb` in the deployment playbook before running `rhui-installer`.