### PR TITLE
check Atomic host version

### DIFF
--- a/docs/atomic_host_checks.rst
+++ b/docs/atomic_host_checks.rst
@@ -1,0 +1,6 @@
+Atomic Host Checks
+==================
+
+.. automodule:: rhui3_tests.test_atomic_host_checks
+   :members:
+   :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Welcome to the RHUI 3 Test Plan!
    :caption: Contents:
    
    atomic_client
+   atomic_host_checks
    cds
    cds_cmd
    client_management

--- a/tests/rhui3_tests/test_atomic_host_checks.py
+++ b/tests/rhui3_tests/test_atomic_host_checks.py
@@ -1,0 +1,58 @@
+'''Atomic Host Checks'''
+
+from os.path import basename
+import re
+import socket
+
+import json
+import logging
+import nose
+import requests
+import stitches
+
+logging.basicConfig(level=logging.DEBUG)
+
+AH = "atomiccli.example.com"
+try:
+    socket.gethostbyname(AH)
+    AH_EXISTS = True
+except socket.error:
+    AH_EXISTS = False
+AH_CON = stitches.Connection(AH, "root", "/root/.ssh/id_rsa_test")
+DOC = "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/" + \
+      "7/html/release_notes/overview"
+VERSION_STRING = "page-next.*Red Hat Enterprise Linux Atomic Host ([0-9.]*)"
+
+def setup():
+    '''
+       announce the beginning of the test run
+    '''
+    print("*** Running %s: *** " % basename(__file__))
+
+def test_01_check_version():
+    '''
+       check if the Atomic host is running the latest documented version
+    '''
+    if not AH_EXISTS:
+        raise nose.exc.SkipTest("No known Atomic host")
+
+    # find the latest version in the docs
+    page = requests.get(DOC)
+    pattern_object = re.compile(VERSION_STRING)
+    match_object = pattern_object.search(page.text)
+    expected_version = match_object.group(1)
+
+    # determine the latest version on the Atomic host
+    _, stdout, _ = AH_CON.exec_command("atomic host status -j")
+    with stdout as output:
+        ah_data = json.load(output)
+    actual_version = ah_data["deployments"][0]["version"]
+
+    # compare the versions
+    nose.tools.eq_(expected_version, actual_version)
+
+def teardown():
+    '''
+       announce the end of the test run
+    '''
+    print("*** Finished running %s. *** " % basename(__file__))


### PR DESCRIPTION
Introducing a new file for various Atomic host checks that aren't real Atomic _client_ tests, and adding one test for now: compare the host version of the AMI with what's in the Atomic docs as the latest released version. The test passes if (and only if) the host is running the version mentioned in the docs:

```
*** Running test_atomic_host_check.py: *** 
check if the Atomic host is running the latest documented version ... ok
*** Finished running test_atomic_host_check.py. *** 

----------------------------------------------------------------------
Ran 1 test in 2.600s

OK
```

The test is skipped in no Atomic host is part of the cloud formation.