### PR TITLE
allow upgrading using an external repo before installing RHUI

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,7 +19,10 @@ Optional variables:
 
 - `common_custom_rpm`=~/Path/To/Your/rh-amazon-rhui-client-rhs30.rpm to setup Gluster
 - `haproxy_rpm`=~/Path/To/Your/haproxy.rpm to setup HAProxy on RHEL6
-- `upgrade_all_pkg`=yes|no|True|TRUE|false to update ALL packages (taking obsoletes into account) prior to RHUI installation. Mind that it might take more than several minutes.
+- `rhel7_beta_baseurl`=URL to create a Yum repo file containing a RHEL 7 compose which wouldn't normally be available on RHEL 7 hosts
+- `rhel8_beta_baseurl`=URL to create a Yum repo file containing a RHEL 8 compose which wouldn't normally be available on RHEL 8 hosts
+- `upgrade_all_pkg`=True to update ALL packages (taking obsoletes into account) prior to RHUI installation. Mind that it might take more than several minutes. Useful when using one or both of the variables above.
+- `reboot`=True to reboot after upgrading (e.g. for a new kernel to boot, for apps to load with a new glibc, etc.). The `upgrade_all_pkg` variable must be `True` at the same time.
 
 This is RHUI3.x [Ansible](https://www.ansible.com) deployment automation.
 Managed roles:

--- a/deploy/cli.yml
+++ b/deploy/cli.yml
@@ -5,5 +5,4 @@
   handlers:
   - include: roles/common/handlers/main.yml
   roles:
-  - common
   - cli

--- a/deploy/roles/common/tasks/upgrade.yml
+++ b/deploy/roles/common/tasks/upgrade.yml
@@ -1,6 +1,29 @@
 # file: roles/common/upgrade.yml
 
+- name: create a yum repo file for an unreleased RHEL 7 compose
+  yum_repository:
+    name: rhel7_beta
+    description: Unreleased RHEL 7 Compose
+    baseurl: "{{ rhel7_beta_baseurl }}"
+    gpgcheck: no
+  when: rhel7_beta_baseurl is defined and ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
+  tags: rhel7_beta
+
+- name: create a yum repo file for an unreleased RHEL 8 compose
+  yum_repository:
+    name: rhel8_beta
+    description: Unreleased RHEL 8 Compose
+    baseurl: "{{ rhel8_beta_baseurl }}"
+    gpgcheck: no
+  when: rhel8_beta_baseurl is defined and ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 8
+  tags: rhel8_beta
+
 - name: upgrade all packages
   package: name=* state=latest update_cache=yes
   when:  upgrade_all_pkg is defined and upgrade_all_pkg | bool and not atomic | default(False)
   tags: upgrade_all_pkg
+
+- name: reboot after upgrading
+  reboot:
+  when: upgrade_all_pkg is defined and upgrade_all_pkg | bool and reboot is defined and reboot | bool and not atomic | default(False)
+  tags: reboot

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,6 +55,7 @@ Default configuration:
   * **--atomic-cli [number]** - number of ATOMIC CLI machines\*, `default = 0`
   * **--test** - if specified, TEST/MASTER machine, `default = 0`
   * **--region [name]** - `default = eu-west-1`
+  * **--ansible-ssh-extra-args [args]** - optional SSH arguments for Ansible
   
 \* ATOMIC CLI machines can be run only with RHEL7 RHUI setup
 

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -90,6 +90,7 @@ argparser.add_argument('--ami-6-override', help='RHEL 6 AMI ID to override the m
 argparser.add_argument('--ami-7-override', help='RHEL 7 AMI ID to override the mapping', metavar='ID')
 argparser.add_argument('--ami-8-override', help='RHEL 8 AMI ID to override the mapping', metavar='ID')
 argparser.add_argument('--ami-atomic-override', help='RHEL Atomic host AMI ID to override the mapping', metavar='ID')
+argparser.add_argument('--ansible-ssh-extra-args', help='Extra arguments for SSH connections established by Ansible', metavar='ARGS')
 
 args = argparser.parse_args()
 
@@ -643,6 +644,8 @@ try:
                 f.write(' ')
                 f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                 f.write(ssh_key)
+                if args.ansible_ssh_extra_args:
+                    f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                 f.write('\n')
         # rhua as nfs
         if fs_type == "rhua":
@@ -653,6 +656,8 @@ try:
                     f.write(' ')
                     f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         # nfs
         elif fs_type == "nfs":
@@ -663,6 +668,8 @@ try:
                     f.write(' ')
                     f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         # gluster
         else:
@@ -673,6 +680,8 @@ try:
                     f.write(' ')
                     f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         # cdses
         f.write('\n[CDS]\n')
@@ -682,6 +691,8 @@ try:
                 f.write(' ')
                 f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                 f.write(ssh_key)
+                if args.ansible_ssh_extra_args:
+                    f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                 f.write('\n')
         # dns
         f.write('\n[DNS]\n')
@@ -692,6 +703,8 @@ try:
                     f.write(' ')
                     f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         else:
             for instance in instances_detail:
@@ -700,6 +713,8 @@ try:
                     f.write(' ')
                     f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         # cli
         if args.cli5 or args.cli6 or args.cli7 or args.cli8:
@@ -723,6 +738,8 @@ try:
                     # remove when Ansible 2.8 is released
                     if instance["OS"] == "RHEL8":
                         f.write(' ansible_python_interpreter=/usr/libexec/platform-python')
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         # atomic_cli
         if args.atomic_cli:
@@ -733,6 +750,8 @@ try:
                     f.write(' ')
                     f.write('atomic=True ansible_ssh_user=cloud-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         # test
         if args.test:
@@ -743,6 +762,8 @@ try:
                     f.write(' ')
                     f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                     f.write(ssh_key)
+                    if args.ansible_ssh_extra_args:
+                        f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                     f.write('\n')
         # haproxy
         f.write('\n[HAPROXY]\n')
@@ -752,6 +773,8 @@ try:
                 f.write(' ')
                 f.write('ansible_ssh_user=ec2-user ansible_become=True ansible_ssh_private_key_file=')
                 f.write(ssh_key)
+                if args.ansible_ssh_extra_args:
+                    f.write(' ansible_ssh_extra_args="%s"' % args.ansible_ssh_extra_args)
                 f.write('\n')
 
 

--- a/scripts/login2cloud.sh
+++ b/scripts/login2cloud.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Use this script to log in to all (non-Atomic) hosts that comprise a RHUI cloud formation.
+#
+# The mandatory first argument is supposed to be the host_*.cfg file created by create-cf-stack.py.
+# The optional second argument can contain extra SSH arguments; typically a reverse tunnel
+# to a web server in a VPN where an unreleased RHEL Beta compose is available and is needed
+# while installing CDS and HAProxy nodes as part of RHUI tests. IOW, if these nodes are running
+# an unreleased RHEL version, you need to be logged in to them with the reverse port for the RHUI
+# tests to be able to install additional packages on them.
+#
+# The `cssh' utility is required.
+if ! which cssh &> /dev/null; then
+  echo "Install cssh first"
+  exit 1
+fi
+if [ "$1" ]; then
+  if [ -f $1 ]; then
+    file=$1
+    hosts=$(awk '/ansible_ssh_user=ec2-user/ { print $1 }' $file | sort -u)
+    key=$(grep -m 1 -o 'ansible_ssh_private_key_file=[^ ]*' $file | cut -d = -f 2)
+  else
+    echo "$1 is not a (hosts) file."
+    exit 1
+  fi
+  cssh -o "-i $key -l ec2-user $2" $hosts
+else
+  echo "Usage: $0 hosts_file [extra_ssh_arguments, e.g. '-R local_port:server_in_your_vpn:port']"
+  exit 1
+fi

--- a/tests/scripts/rhuitests
+++ b/tests/scripts/rhuitests
@@ -92,11 +92,15 @@ identity=~/.ssh/id_rsa_test
 export PYTHONUNBUFFERED=1
 
 if [[ $1 == all ]]; then
+    rhua_info=$(ssh -i $identity -o StrictHostKeyChecking=no -q rhua.example.com "cat /etc/redhat-release")
+    client_info=$(ssh -i $identity -o StrictHostKeyChecking=no -q cli01.example.com "cat /etc/redhat-release")
     if [[ $2 == quiet ]]; then
-        nosetests -vs &> $output
+        echo "The RHUA is running on $rhua_info. The client is running on $client_info." > $output
+        nosetests -vs &>> $output
         result=$?
     else
-        nosetests -vs 2>&1 | tee $output
+        echo "The RHUA is running on $rhua_info. The client is running on $client_info." | tee $output
+        nosetests -vs 2>&1 | tee -a $output
         result=${PIPESTATUS[0]}
     fi
 elif [[ $1 == client ]]; then


### PR DESCRIPTION
Use the changes in this commit to define a repo containing any updates you want to apply before installing RHUI. Typically, you may want to install and test RHUI on RHEL 7.Y+1 {Alpha,Beta,Snapshot N} while only 7.Y is available publicly. Or you want to test RHEL 8.Y+1 as a client. Then instruct Ansible to upgrade all packages and (optionally but preferably) reboot all the affected systems before moving on.

If the unreleased RHEL version is only available in your VPN, use the enhancements from this commit to define a reverse SSH tunnel that will provide access to a (web) server where the packages are stored. This tunnel will be used by Ansible automatically, so you don't have to log in manually. However, if you use Ansible to only install RHUI and want to run tests separately, you need to log in manually using the tunnel before starting the tests, and keep the tunnel open for the duration of the tests. In that case you can take advantage of the new `login2cloud.sh` script in the `scripts` directory. (See its usage message.)

As a bonus, the `rhuitests` script now prints the RHEL version on the RHUA and CLI nodes when all tests are executed. This is to prove that the tests ran on the Beta version of RHEL (if that's the case).