### PR TITLE
drop support for RHUI on RHEL 6 (excl. clients)

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,7 +1,7 @@
 Requirements
 ---------------
 * [Ansible](http://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-release-via-dnf-or-yum) version 2.8 and later.
-* Have enough machines ready - check the rest of Read Me for details on various RHUI setups.
+* Have enough machines running RHEL 7 ready - check the rest of Read Me for details on various RHUI setups.
 * Have RHUI3 ISO.
 
 Usage
@@ -18,14 +18,13 @@ Mind the mandatory extra variable `rhui_iso`
 Optional variables:
 
 - `common_custom_rpm`=~/Path/To/Your/rh-amazon-rhui-client-rhs30.rpm to setup Gluster
-- `haproxy_rpm`=~/Path/To/Your/haproxy.rpm to setup HAProxy on RHEL6
 - `rhel7_beta_baseurl`=URL to create a Yum repo file containing a RHEL 7 compose which wouldn't normally be available on RHEL 7 hosts
 - `rhel8_beta_baseurl`=URL to create a Yum repo file containing a RHEL 8 compose which wouldn't normally be available on RHEL 8 hosts; use the BaseOS repo URL here, the corresponding AppStream repo file will be created automatically
 - `upgrade_all_pkg`=True to update ALL packages (taking obsoletes into account) prior to RHUI installation. Mind that it might take more than several minutes. This will affect all the hosts except for Atomic
 
 Note that if you use `rhel7_beta_baseurl`, all RHEL 7 systems will get upgraded and rebooted automatically. Ditto for `rhel8_beta_baseurl`. This will allow a new kernel to boot, apps to load with a new glibc, etc.
 
-This is RHUI3.x [Ansible](https://www.ansible.com) deployment automation.
+This is RHUI 3.1+ [Ansible](https://www.ansible.com) deployment automation.
 Managed roles:
 - Dns
 - Rhua

--- a/deploy/roles/dns/tasks/main.yml
+++ b/deploy/roles/dns/tasks/main.yml
@@ -41,17 +41,3 @@
 - name: workaround over
   service: name=network state=restarted
   tags: dns
-
-- name: install NetworkManager
-  package: name=NetworkManager state=installed
-  delegate_to: "{{ item }}"
-  with_items: "{{ groups['CDS']|default([]) + groups['HAPROXY']|default([]) + groups['RHUA']|default([]) + groups['DNS']|default([]) + groups['NFS']|default([]) + groups['GLUSTER']|default([]) + groups['CLI']|default([]) }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
-  tags: dns
-
-- name: start NetworkManager service
-  service: name=NetworkManager state=started
-  delegate_to: "{{ item }}"
-  with_items: "{{ groups['CDS']|default([]) + groups['HAPROXY']|default([]) + groups['RHUA']|default([]) + groups['DNS']|default([]) + groups['NFS']|default([]) + groups['GLUSTER']|default([]) + groups['CLI']|default([]) }}"
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
-  tags: dns

--- a/deploy/roles/haproxy/tasks/main.yml
+++ b/deploy/roles/haproxy/tasks/main.yml
@@ -1,27 +1,9 @@
 ---
 # file: roles/haproxy/tasks/main.yml
-# deploy & configure named on a host
+# set up the HAProxy node; just the hostname in fact
 
 - name: set hostname
   hostname: name="hap0{{ item.0 + 1 }}.example.com"
   with_indexed_items: "{{ groups['HAPROXY'] }}"
   when: "'HAPROXY' in groups and item.1 == inventory_hostname"
-  tags: haproxy
-
-- name: copy remote haproxy rpm
-  copy: src={{haproxy_rpm}} dest=/tmp
-  when: >
-    ansible_os_family == "RedHat" and
-    ansible_distribution_major_version|int == 6 and
-    haproxy_rpm is defined
-  register: copy_haproxy_rpm_result
-  tags: haproxy
-
-- name: install haproxy rpm
-  package: name='/tmp/{{haproxy_rpm|basename}}' state=present
-  when: >
-    ansible_os_family == "RedHat" and
-    ansible_distribution_major_version|int == 6 and
-    haproxy_rpm is defined and
-    copy_haproxy_rpm_result is success
   tags: haproxy

--- a/deploy/roles/nfs/tasks/main.yml
+++ b/deploy/roles/nfs/tasks/main.yml
@@ -30,28 +30,15 @@
     state: mounted
   tags: nfs
 
-- name: start rpcbind service
+- name: start the rpcbind service
   service: name=rpcbind state=started enabled=yes
   tags: nfs
 
-- name: start nfs service if RHEL6
-  service: name=nfs state=started enabled=yes
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
-  tags: nfs
-
-- name: entry info in /etc/exports
-  template: src=exports.j2 dest=/etc/exports
-  notify: restart nfs
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
-  tags: nfs
-
-- name: start nfs-server service if RHEL7
+- name: start the nfs-server service
   service: name=nfs-server state=started enabled=yes
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
   tags: nfs
 
-- name: entry info in /etc/exports
+- name: set up the /etc/exports file
   template: src=exports.j2 dest=/etc/exports
   notify: restart nfs-server
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 7
   tags: nfs

--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -16,47 +16,12 @@
     dest: /root/rhui3-automation
   tags: tests
 
-- name: install the 'Development tools' package group
-  package: name="@Development tools" state=present
-  tags: tests
-
-- name: install python-devel
-  package: name=python-devel state=present
-  tags: tests
-
-- name: install python-setuptools
-  package: name=python-setuptools state=present
-  tags: tests
-
-- name: install libffi-devel
-  package: name=libffi-devel state=present enablerepo=*
-  tags: tests
-
-- name: install openssl-devel
-  package: name=openssl-devel state=present enablerepo=*
-  tags: tests
-
 - name: install bash-completion to simplify test execution
   package: name=bash-completion state=present
   tags: tests
 
-- name: use HTTPS in the pypi URL in setuptools if RHEL 6
-  lineinfile:
-    path: /usr/lib/python2.6/site-packages/setuptools/command/easy_install.py
-    regexp: '^(.*)http://pypi.python.org(.*)$'
-    line: '\1https://pypi.python.org\2'
-    backrefs: yes
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
-  tags: tests
-
-- name: install the last compatible versions of packages whose updates need Python 2.7+
-  shell: easy_install pip==9.0.3 && pip install pycparser==2.18
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int == 6
-  tags: tests
-
 - name: install pip
   shell: easy_install pip
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
   tags: tests
 
 - name: install tests

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,10 +4,10 @@
 
 Script creates ec2 instance machines (m3.large) according to specification.
 
-Instances are named `$user_name_$RHELrelease_$filesystem_type$iso_date_$role` (*user_RHEL7_nfs_20160809_rhua*)
+Instances are named `$user_$fstype_$iso_$role` (*user_nfs_20190708_rhua*)
 
 The script produces an output config file suitable for the RHUI3 ansible installation. [Example](#output-configuration-file) of the output file. Default
-name of the file is `hosts_$RHEL_release_$filesystem_type_$iso.cfg` (*hosts_RHEL7_nfs_20160809.cfg*)
+name of the file is `hosts_$fstype_$iso.cfg` (*hosts_nfs_20190708.cfg*)
 
 New security group is created. Its name contains stack id. <br />
 Inbound rules:
@@ -37,27 +37,27 @@ Run `scripts/create-cf-stack.py [optional parameters]` [(example)](#usage-exampl
 
 Default configuration: 
   * NFS filesystem
-  * RHEL6 instances
+  * RHEL7 instances (basic RHUI 3 requirement)
   * eu-west-1 region
   * instances: 1xRHUA (NFS, DNS), 1xCDS, 1xHAProxy
 
-#### Parameters
+#### Main parameters
 
-  * **--rhua [rhel_version]** - RHEL version for RHUI setup, `default = RHEL6`
-  * **--iso [iso_date]** - iso version to title the instance (as in $user_nick_$RHELrelease_$ROLE_*$iso_date)*
+  * **--iso [iso_date]** - iso version to title the instance (as in $user_$fstype_$iso_$role)
+  * **--gluster** - use GlusterFS instead of NFS
   * **--dns** - if specified, a separate machine for dns, `default = the same as RHUA`
   * **--cds [number]** - number of CDS machines, `default = 1` (if Gluster filesystem, `default = 3`)
   * **--haproxy [number]** - number of HAProxies, `default = 1`
   * **--input-conf [name]** - the name of input conf file, `default = "/etc/rhui_ec2.yaml"`
-  * **--output-conf [name]** - the name of output conf file, `default = "hosts_$RHELrelease_$iso.cfg"`
+  * **--output-conf [name]** - the name of output conf file, `default = "hosts_$fstype_$iso.cfg"`
   * **--cli5/6/7/8 [number]** - number of CLI machines, `default = 0`, use `-1` to get machines for all architectures (one machine per architecture)
   * **--cli7/8-arch [arch]** - CLI machines' architectures (comma-separated list), `default = x86_64 for all of them`, `cli`_N_ set to `-1` will populate the list with all architectures automatically, so this parameter is unnecessary then
   * **--atomic-cli [number]** - number of ATOMIC CLI machines\*, `default = 0`
   * **--test** - if specified, TEST/MASTER machine, `default = 0`
   * **--region [name]** - `default = eu-west-1`
   * **--ansible-ssh-extra-args [args]** - optional SSH arguments for Ansible
-  
-\* ATOMIC CLI machines can be run only with RHEL7 RHUI setup
+
+Run the script with `-h` or `--help` to get a list of all parameters.
 
 Note that RHEL-5 AMIs are not available in all regions;
 see the [RHEL 5 mapping file](RHEL5mapping.json).
@@ -104,20 +104,20 @@ There is an extra 100 GB volume attached to each CDS machine.
 
 #### Usage example
 
-* `scripts/create-cf-stack.py --iso 20160809`
-  * basic RHEL6 NFS configuration
+* `scripts/create-cf-stack.py --iso 20190708`
+  * basic NFS configuration
   * 1xRHUA=DNS=NFS, 1xCDS, 1xHAProxy
-* `scripts/create-cf-stack.py --rhua RHEL7 --test --gluster --iso 20160809`
-  * RHEL7 Gluster configuration
+* `scripts/create-cf-stack.py --test --gluster --iso 20190708`
+  * Gluster configuration
   * 1xRHUA=DNS, 3xCDS, 1xHAProxy, 1xtest_machine
-* `scripts/create-cf-stack.py --region eu-central-1 --nfs cli6 2 --haproxy 2 --iso 20160809`
-  * RHEL6 NFS configuration on eu-central-1 region
+* `scripts/create-cf-stack.py --region eu-central-1 --nfs cli6 2 --haproxy 2 --iso 20190708`
+  * NFS configuration in the eu-central-1 region
   * 1xRHUA=DNS, 1xNFS, 2xCLI6, 2xHAProxy
-* `scripts/create-cf-stack.py --rhua RHEL7 --dns --cds 2 --cli6 1 --cli7 1 --input-conf /etc/rhui_amazon.yaml --output-conf my_new_hosts_config_file.cfg --iso 20160809`
-  * RHEL7 NFS configuration
+* `scripts/create-cf-stack.py --dns --cds 2 --cli6 1 --cli7 1 --input-conf /etc/rhui_amazon.yaml --output-conf my_new_hosts_config_file.cfg --iso 20190708`
+  * NFS configuration
   * 1xRHUA=NFS, 1xDNS, 2xCDS, 1xCLI6, 1xCLI7, 1xHAProxy
-* `scripts/create-cf-stack.py --input-conf rhui_ec2.yaml --rhua RHEL7 --iso rhel8clients --cli8 -1 --test --vpcid vpc-012345678 --subnetid subnet-89abcdef`
-  * RHEL7 NFS configuration
+* `scripts/create-cf-stack.py --input-conf rhui_ec2.yaml --iso rhel8clients --cli8 -1 --test --vpcid vpc-012345678 --subnetid subnet-89abcdef`
+  * NFS configuration
   * custom input configuration file in the current working directory
   * 1xRHUA=NFS=DNS, 1xCDS, 1xHAProxy, 2xCLI8 (x86_64 and ARM64), 1xTEST, custom VPC and subnet (needed by the `a1` instance type used with ARM64)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,11 +4,11 @@ Setup of the RHUI 3 Test Framework
 
 Requirements
 ---------------
-Python 2 or 3. Tested on Python 2.6, 2.7, and 3.6.
+Python 2 or 3. Tested on Python 2.7, and 3.6.
 
 The latest released RHUI 3 ISO. If you use an older ISO, you will get failures from the test cases that cover bug fixes or features from newer releases.
 
-RHUI deployment with the following hosts running either RHEL 6 or 7:
+RHUI deployment with the following hosts running RHEL 7:
 
 * one RHUA instance
 * at least one CDS instance if using NFS, at least three if using Gluster

--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -31,9 +31,6 @@ class TestClient(object):
     '''
 
     def __init__(self):
-        rhua_os_version = Util.get_rhel_version(CONNECTION)["major"]
-        if rhua_os_version < 7:
-            raise nose.exc.SkipTest("Not supported on RHEL %s" % rhua_os_version)
         try:
             socket.gethostbyname(AH)
             self.ah_exists = True

--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -33,8 +33,9 @@ class TestRepo(object):
         self.custom_rpms = Util.get_rpms_in_dir(CONNECTION, CUSTOM_RPMS_DIR)
         if not self.custom_rpms:
             raise RuntimeError("No custom RPMs to test in %s" % CUSTOM_RPMS_DIR)
-        version = Util.get_rhel_version(CONNECTION)["major"]
-        arch = Util.get_arch(CONNECTION)
+        # Test the RHEL-6 repo for a change
+        version = 6
+        arch = "x86_64"
         with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:

--- a/tests/rhui3_tests/test_rhui_3_repos.py
+++ b/tests/rhui3_tests/test_rhui_3_repos.py
@@ -72,26 +72,20 @@ def test_01_install_wget():
     '''
     Expect.expect_retval(CONNECTION, "yum -y install wget", timeout=30)
 
-def test_02_rhui_3_for_rhel_6_check():
-    '''
-        check if the RHUI 3 packages for RHEL 6 are available
-    '''
-    _check_rpms(6, 100)
-
-def test_03_rhui_3_for_rhel_7_check():
+def test_02_rhui_3_for_rhel_7_check():
     '''
         check if the RHUI 3 packages for RHEL 7 are available
     '''
     _check_rpms(7, 100)
 
-def test_04_eus_6_repos_check():
+def test_03_eus_6_repos_check():
     '''
         check if all supported RHEL 6 EUS versions are available
     '''
     # RHEL 6.1-6.7
     _check_listing(6, 1, 7)
 
-def test_05_eus_7_repos_check():
+def test_04_eus_7_repos_check():
     '''
         check if all supported RHEL 7 EUS versions are available
     '''

--- a/tests/rhui3_tests/test_sync_management.py
+++ b/tests/rhui3_tests/test_sync_management.py
@@ -23,8 +23,9 @@ class TestSync(object):
     '''
 
     def __init__(self):
-        version = Util.get_rhel_version(CONNECTION)["major"]
-        arch = Util.get_arch(CONNECTION)
+        # Test the RHEL-7 ARM-64 repo for a change
+        version = 7
+        arch = "aarch64"
         with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:

--- a/tests/rhui3_tests/test_updateinfo.py
+++ b/tests/rhui3_tests/test_updateinfo.py
@@ -198,6 +198,10 @@ class TestClient(object):
         '''
            also check if an uncompressed updateinfo.xml file can be used
         '''
+        # RHEL 6 uses the same set of errata; let's remove errata from MongoDB first so they
+        # can actually be uploaded from the uncompressed XML
+        if self.test["repo_id"] == self.test["uncompressed_updateinfo"]:
+            Expect.expect_retval(RHUA, "mongo pulp_database --eval 'db.units_erratum.remove({})'")
         RHUIManagerCLI.repo_add_errata(RHUA,
                                        self.test["repo_id"],
                                        "/tmp/extra_rhui_files/%s/updateinfo.xml" % \

--- a/tests/rhui3_tests/test_zzz_misc.py
+++ b/tests/rhui3_tests/test_zzz_misc.py
@@ -7,8 +7,6 @@ import nose
 import stitches
 from stitches.expect import Expect
 
-from rhui3_tests_lib.util import Util
-
 RHUA = stitches.Connection("rhua.example.com", "root", "/root/.ssh/id_rsa_test")
 
 RHUI_SERVICE_PIDFILES = ["/var/run/httpd/httpd.pid",
@@ -87,12 +85,7 @@ def test_05_celery_selinux():
         verify that no SELinux denial related to celery was logged
     '''
     # for RHBZ#1608166 - anyway, only non-fatal denials are expected if everything else works
-    rhua_rhel_version = Util.get_rhel_version(RHUA)["major"]
-    if rhua_rhel_version < 7:
-        output = r"audit2allow\r\n\r\n\r\n\[root@rhua ~\]"
-    else:
-        output = "Nothing to do"
-    Expect.ping_pong(RHUA, "grep celery /var/log/audit/audit.log | audit2allow", output)
+    Expect.ping_pong(RHUA, "grep celery /var/log/audit/audit.log | audit2allow", "Nothing to do")
 
 def test_06_pulp_server_rpm_v():
     '''

--- a/tests/rhui3_tests_lib/rhuimanager_instance.py
+++ b/tests/rhui3_tests_lib/rhuimanager_instance.py
@@ -40,10 +40,7 @@ class RHUIManagerInstance(object):
 
         # first check if the RHUA knows the host's SSH key, because if so, rhui-manager
         # won't ask you to confirm the key
-        # the following command doesn't work as expected on RHEL 6:
-        # key_check_cmd = "ssh-keygen -F %s" % hostname
-        # work around that:
-        key_check_cmd = "grep -q ^%s, /root/.ssh/known_hosts" % hostname
+        key_check_cmd = "ssh-keygen -F %s" % hostname
         # check if the host is known
         known_host = connection.recv_exit_status(key_check_cmd) == 0
         # run rhui-manager and add the instance

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -5,20 +5,10 @@
 '''
 
 from glob import glob
-import sys
 
 from setuptools import setup
 
-REQUIREMENTS = ['nose>=1.3.0', 'requests', 'stitches>=0.12']
-
-# Workarounds for packages whose latest versions cannot be installed on RHEL 6
-PYTHON_VERSION = sys.version_info[0] + sys.version_info[1] / 10.0
-if PYTHON_VERSION <= 2.6:
-    REQUIREMENTS.append('paramiko==2.3.1')
-    REQUIREMENTS.append('idna==2.7')
-    REQUIREMENTS.append('pytoml==0.1.19')
-else:
-    REQUIREMENTS.append('pytoml')
+REQUIREMENTS = ['nose>=1.3.0', 'pytoml', 'requests', 'stitches>=0.12']
 
 DATAFILES = [('share/rhui3_tests_lib/rhui3_tests', glob('rhui3_tests/test_*.py')),
              ('share/rhui3_tests_lib/config', ['rhui3_tests/tested_repos.yaml']),


### PR DESCRIPTION
RHUI 3 Automation was written when RHUI 3 was supported on RHEL 6 and 7. Many hacks were introduced to ensure RHEL 6 compatibility. At present, however, only RHEL 7 is supported. Consequently, these hacks are no longer needed. I'm removing them to simplify the code and get rid of conditions that never/always pass now. I'm also hiding the --rhua parameter from the stack creation script. One can still use it, e.g. because of its potential presence in scripts or bash history, but it'll be ignored and an info message will be logged when this parameter is used.

Lastly, as there's a test repo that was used when the RHUA was running RHEL 6, and this repo wouldn't be tested anymore, I've set it as a test repo in the repo management tests. While I was at it, I also modified the sync management tests to use yet another repo instead of the one corresponding to the RHUA RHEL version & arch.

Note that you can still have one or more RHEL 6 clients and test them any way you want; RHUI still supports RHEL 6 as a _client_ anyway.