### PR TITLE
rename --iso to --name

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,10 +4,10 @@
 
 Script creates ec2 instance machines (m3.large) according to specification.
 
-Instances are named `$user_$fstype_$iso_$role` (*user_nfs_20190708_rhua*)
+Instances are named `$user_$fstype_$name_$role` (*user_nfs_77betatests_rhua*)
 
 The script produces an output config file suitable for the RHUI3 ansible installation. [Example](#output-configuration-file) of the output file. Default
-name of the file is `hosts_$fstype_$iso.cfg` (*hosts_nfs_20190708.cfg*)
+name of the file is `hosts_$fstype_$name.cfg` (*hosts_nfs_77betatests.cfg*)
 
 New security group is created. Its name contains stack id. <br />
 Inbound rules:
@@ -43,16 +43,16 @@ Default configuration:
 
 #### Main parameters
 
-  * **--iso [iso_date]** - iso version to title the instance (as in $user_$fstype_$iso_$role)
+  * **--name [name]** - common name for the instances in the stack (as in $user_$fstype_$name_$role); also affects the `hosts` file name (unless overridden). `default = rhui`
   * **--gluster** - use GlusterFS instead of NFS
   * **--dns** - if specified, a separate machine for dns, `default = the same as RHUA`
   * **--cds [number]** - number of CDS machines, `default = 1` (if Gluster filesystem, `default = 3`)
   * **--haproxy [number]** - number of HAProxies, `default = 1`
   * **--input-conf [name]** - the name of input conf file, `default = "/etc/rhui_ec2.yaml"`
-  * **--output-conf [name]** - the name of output conf file, `default = "hosts_$fstype_$iso.cfg"`
+  * **--output-conf [name]** - the name of output conf file, `default = "hosts_$fstype_$name.cfg"`
   * **--cli5/6/7/8 [number]** - number of CLI machines, `default = 0`, use `-1` to get machines for all architectures (one machine per architecture)
   * **--cli7/8-arch [arch]** - CLI machines' architectures (comma-separated list), `default = x86_64 for all of them`, `cli`_N_ set to `-1` will populate the list with all architectures automatically, so this parameter is unnecessary then
-  * **--atomic-cli [number]** - number of ATOMIC CLI machines\*, `default = 0`
+  * **--atomic-cli [number]** - number of ATOMIC CLI machines, `default = 0`
   * **--test** - if specified, TEST/MASTER machine, `default = 0`
   * **--region [name]** - `default = eu-west-1`
   * **--ansible-ssh-extra-args [args]** - optional SSH arguments for Ansible
@@ -104,19 +104,19 @@ There is an extra 100 GB volume attached to each CDS machine.
 
 #### Usage example
 
-* `scripts/create-cf-stack.py --iso 20190708`
+* `scripts/create-cf-stack.py`
   * basic NFS configuration
   * 1xRHUA=DNS=NFS, 1xCDS, 1xHAProxy
-* `scripts/create-cf-stack.py --test --gluster --iso 20190708`
+* `scripts/create-cf-stack.py --test --gluster --name playpit`
   * Gluster configuration
   * 1xRHUA=DNS, 3xCDS, 1xHAProxy, 1xtest_machine
-* `scripts/create-cf-stack.py --region eu-central-1 --nfs cli6 2 --haproxy 2 --iso 20190708`
+* `scripts/create-cf-stack.py --region eu-central-1 --nfs cli6 2 --haproxy 2 --name rhui31wip`
   * NFS configuration in the eu-central-1 region
   * 1xRHUA=DNS, 1xNFS, 2xCLI6, 2xHAProxy
-* `scripts/create-cf-stack.py --dns --cds 2 --cli6 1 --cli7 1 --input-conf /etc/rhui_amazon.yaml --output-conf my_new_hosts_config_file.cfg --iso 20190708`
+* `scripts/create-cf-stack.py --dns --cds 2 --cli6 1 --cli7 1 --input-conf /etc/rhui_amazon.yaml --output-conf my_new_hosts_config_file.cfg --name cdsdebug`
   * NFS configuration
   * 1xRHUA=NFS, 1xDNS, 2xCDS, 1xCLI6, 1xCLI7, 1xHAProxy
-* `scripts/create-cf-stack.py --input-conf rhui_ec2.yaml --iso rhel8clients --cli8 -1 --test --vpcid vpc-012345678 --subnetid subnet-89abcdef`
+* `scripts/create-cf-stack.py --input-conf rhui_ec2.yaml --name rhel8clients --cli8 -1 --test --vpcid vpc-012345678 --subnetid subnet-89abcdef`
   * NFS configuration
   * custom input configuration file in the current working directory
   * 1xRHUA=NFS=DNS, 1xCDS, 1xHAProxy, 2xCLI8 (x86_64 and ARM64), 1xTEST, custom VPC and subnet (needed by the `a1` instance type used with ARM64)

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -52,8 +52,9 @@ instance_types = {"arm64": "a1.large", "x86_64": "m3.large"}
 
 argparser = argparse.ArgumentParser(description='Create CloudFormation stack')
 argparser.add_argument('--rhua', help=argparse.SUPPRESS)
+argparser.add_argument('--iso', help=argparse.SUPPRESS)
 
-argparser.add_argument('--iso', help='iso version', default="iso")
+argparser.add_argument('--name', help='common name for stack members', default='rhui')
 argparser.add_argument('--cli5', help='number of RHEL5 clients', type=int, default=0)
 argparser.add_argument('--cli6', help='number of RHEL6 clients', type=int, default=0)
 argparser.add_argument('--cli7', help='number of RHEL7 clients', type=int, default=0)
@@ -157,6 +158,10 @@ if args.cli8 == -1:
 if args.rhua:
     logging.info("The --rhua parameter is deprecated. " +
                  "RHEL 7 is used on all nodes except for clients that you set up differently.")
+if args.iso:
+    logging.info("The --iso parameter is deprecated. Use --name instead. " +
+                 "Using '%s' as the name to keep compatibility & for your convenience." % args.iso)
+    args.name = args.iso
 rhui_os = "RHEL7"
 
 json_dict['Description'] = 'RHUI with %s CDSes' % args.cds
@@ -304,7 +309,7 @@ if (fs_type == "rhua"):
                                             },
                                  ],
                                u'Tags': [{u'Key': u'Name',
-                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'rhua']]}},
+                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'rhua']]}},
                                          {u'Key': u'Role', u'Value': u'RHUA'},
                                          ]},
                u'Type': u'AWS::EC2::Instance'}
@@ -322,7 +327,7 @@ else:
                                             },
                                  ],
                                u'Tags': [{u'Key': u'Name',
-                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'rhua']]}},
+                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'rhua']]}},
                                          {u'Key': u'Role', u'Value': u'RHUA'},
                                          ]},
                u'Type': u'AWS::EC2::Instance'}
@@ -343,7 +348,7 @@ if (fs_type == "gluster"):
                                    u'KeyName': {u'Ref': u'KeyName'},
                                    u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                    u'Tags': [{u'Key': u'Name',
-                                              u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'cds%i' % i]]}},
+                                              u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'cds%i' % i]]}},
                                              {u'Key': u'Role', u'Value': u'CDS'},
                                              ]},
                    u'Type': u'AWS::EC2::Instance'}
@@ -356,7 +361,7 @@ else:
                                    u'KeyName': {u'Ref': u'KeyName'},
                                    u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                    u'Tags': [{u'Key': u'Name',
-                                              u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'cds%i' % i]]}},
+                                              u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'cds%i' % i]]}},
                                              {u'Key': u'Role', u'Value': u'CDS'},
                                              ]},
                    u'Type': u'AWS::EC2::Instance'}
@@ -391,7 +396,7 @@ for i in (5, 6, 7, 8):
                                    u'KeyName': {u'Ref': u'KeyName'},
                                    u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                    u'Tags': [{u'Key': u'Name',
-                                              u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'cli%i_%i' % (i, j)]]}},
+                                              u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'cli%i_%i' % (i, j)]]}},
                                              {u'Key': u'Role', u'Value': u'CLI'},
                                              {u'Key': u'OS', u'Value': u'%s' % os[:5]}]},
                    u'Type': u'AWS::EC2::Instance'}
@@ -404,7 +409,7 @@ for i in range(1, args.atomic_cli + 1):
                                u'KeyName': {u'Ref': u'KeyName'},
                                u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                u'Tags': [{u'Key': u'Name',
-                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'atomic_cli%i' % i]]}},
+                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'atomic_cli%i' % i]]}},
                                          {u'Key': u'Role', u'Value': u'ATOMIC_CLI'},
                                          ]},
                u'Type': u'AWS::EC2::Instance'}
@@ -423,7 +428,7 @@ if (fs_type == "nfs"):
                                             },
                                  ],
                                u'Tags': [{u'Key': u'Name',
-                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'nfs']]}},
+                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'nfs']]}},
                                          {u'Key': u'Role', u'Value': u'NFS'},
                                          ]},
                u'Type': u'AWS::EC2::Instance'}
@@ -436,7 +441,7 @@ if args.dns:
                                u'KeyName': {u'Ref': u'KeyName'},
                                u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                u'Tags': [{u'Key': u'Name',
-                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'dns']]}},
+                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'dns']]}},
                                          {u'Key': u'Role', u'Value': u'DNS'},
                                          ]},
                u'Type': u'AWS::EC2::Instance'}
@@ -449,7 +454,7 @@ if args.test:
                                u'KeyName': {u'Ref': u'KeyName'},
                                u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                u'Tags': [{u'Key': u'Name',
-                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'test']]}},
+                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'test']]}},
                                          {u'Key': u'Role', u'Value': u'TEST'},
                                          ]},
                u'Type': u'AWS::EC2::Instance'}
@@ -462,7 +467,7 @@ for i in range(1, args.haproxy + 1):
                                u'KeyName': {u'Ref': u'KeyName'},
                                u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],
                                u'Tags': [{u'Key': u'Name',
-                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.iso, u'haproxy%i' % i]]}},
+                                          u'Value': {u'Fn::Join': [u'_', [ec2_name, fs_type_f, args.name, u'haproxy%i' % i]]}},
                                          {u'Key': u'Role', u'Value': u'HAProxy'},
                                          ]},
                    u'Type': u'AWS::EC2::Instance'}
@@ -634,7 +639,7 @@ for instance in instances_detail:
 if args.output_conf:
     outfile = args.output_conf
 else:
-    outfile = "hosts_%s_%s.cfg" % (fs_type_f, args.iso)
+    outfile = "hosts_%s_%s.cfg" % (fs_type_f, args.name)
 
 try:
     with open(outfile, 'w') as f:


### PR DESCRIPTION
It makes more sense now to refer to stacks for RHUI testing using names describing the purpose of the testing. While ISOs are still used to install RHUI from, their build dates no longer necessarily represent what you want to do with the given stack.

This commit preserves the `--iso` parameter so execution won't fail if you still use `--iso`; its value will be used as the name automatically, and an info message will be logged.