### PR TITLE
include the name in the stack ID

### DIFF
--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -514,7 +514,7 @@ if not con_cf or not con_ec2:
     logging.error("Create CF/EC2 connections: " + args.region)
     sys.exit(1)
 
-STACK_ID = "STACK" + "-" + ec2_name + "-" + ''.join(random.choice(string.ascii_lowercase) for x in range(10))
+STACK_ID = "STACK-%s-%s-%s" % (ec2_name, args.name, ''.join(random.choice(string.ascii_lowercase) for x in range(10)))
 logging.info("Creating stack with ID " + STACK_ID)
 
 parameters = []


### PR DESCRIPTION
At present, the list of stacks on the CloudFormation page contains IDs such as `STACK-rbiba-eqnuchovna`. I can tell from this ID that the stack is mine, but if I have multiple stacks at a time, I can't tell which one has which purpose, which isn't optimal when I want to delete a particular stack.

The purpose can be specified as the stack name and then it's part of the name for each instance, e.g. `78alpha` in `rbiba_nfs_78alpha_test`. With this commit the name becomes also part of the stack ID, `STACK-rbiba-<name>-aqhgpvbiw`, so it's easier to identify the stack on the CloudFormation page.