### PR TITLE
allow a RHEL-8 test machine

### DIFF
--- a/deploy/roles/cli/tasks/main.yml
+++ b/deploy/roles/cli/tasks/main.yml
@@ -33,3 +33,14 @@
     ansible_os_family == "RedHat" and
     ansible_distribution_major_version|int == 8
   tags: cli
+
+- name: create the platform-python symlink if RHEL6
+  file:
+    src: /usr/bin/python
+    dest: /usr/libexec/platform-python
+    state: link
+  when: >
+    "'CLI' in groups" and
+    ansible_os_family == "RedHat" and
+    ansible_distribution_major_version|int == 6
+  tags: cli

--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -21,7 +21,7 @@
   tags: tests
 
 - name: install pip
-  shell: easy_install pip
+  shell: if grep -q 'release 8' /etc/redhat-release; then easy_install-3.6 --prefix /usr pip; else easy_install pip; fi
   tags: tests
 
 - name: install tests
@@ -29,7 +29,7 @@
   tags: tests
 
 - name: generate ssh keys
-  command: ssh-keygen -N "" -f /root/.ssh/id_rsa_test creates=/root/.ssh/id_rsa_test
+  command: ssh-keygen -m pem -N "" -f /root/.ssh/id_rsa_test creates=/root/.ssh/id_rsa_test
   notify: restorecon root ssh
   register: generated_ssh_test_keys
   tags: tests

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -53,7 +53,8 @@ Default configuration:
   * **--cli5/6/7/8 [number]** - number of CLI machines, `default = 0`, use `-1` to get machines for all architectures (one machine per architecture)
   * **--cli7/8-arch [arch]** - CLI machines' architectures (comma-separated list), `default = x86_64 for all of them`, `cli`_N_ set to `-1` will populate the list with all architectures automatically, so this parameter is unnecessary then
   * **--atomic-cli [number]** - number of ATOMIC CLI machines, `default = 0`
-  * **--test** - if specified, TEST/MASTER machine, `default = 0`
+  * **--test** - if specified, TEST/MASTER machine running RHEL 7, `default = 0`
+  * **--test8** - if specified, TEST/MASTER machine running RHEL 8, `default = 0`
   * **--region [name]** - `default = eu-west-1`
   * **--ansible-ssh-extra-args [args]** - optional SSH arguments for Ansible
 

--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -66,7 +66,8 @@ argparser.add_argument('--dns', help='DNS', action='store_const', const=True, de
 argparser.add_argument('--nfs', help='NFS', action='store_const', const=True, default=False)
 argparser.add_argument('--haproxy', help='number of HAProxies', type=int, default=1)
 argparser.add_argument('--gluster', help='Gluster', action='store_const', const=True, default=False)
-argparser.add_argument('--test', help='test machine', action='store_const', const=True, default=False)
+argparser.add_argument('--test', help='test machine with RHEL 7', action='store_const', const=True, default=False)
+argparser.add_argument('--test8', help='test machine with RHEL 8 (overrides --test)', action='store_const', const=True, default=False)
 argparser.add_argument('--atomic-cli', help='number of Atomic CLI machines', type=int, default=0)
 argparser.add_argument('--input-conf', default="/etc/rhui_ec2.yaml", help='use supplied yaml config file')
 argparser.add_argument('--output-conf', help='output file')
@@ -154,6 +155,9 @@ if args.cli7 == -1:
 if args.cli8 == -1:
     args.cli8 = len(instance_types)
     args.cli8_arch = ",".join(instance_types.keys())
+
+if args.test8:
+    args.test = True
 
 if args.rhua:
     logging.info("The --rhua parameter is deprecated. " +
@@ -448,8 +452,9 @@ if args.dns:
 
 # test
 if args.test:
+    os = "RHEL8" if args.test8 else rhui_os
     json_dict['Resources']["test"] = \
-     {u'Properties': {u'ImageId': {u'Fn::FindInMap': [rhui_os, {u'Ref': u'AWS::Region'}, u'AMI']},
+     {u'Properties': {u'ImageId': {u'Fn::FindInMap': [os, {u'Ref': u'AWS::Region'}, u'AMI']},
                                u'InstanceType': args.r3 and u'r3.xlarge' or u'm3.large',
                                u'KeyName': {u'Ref': u'KeyName'},
                                u'SecurityGroups': [{u'Ref': u'RHUIsecuritygroup'}],

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,7 +15,7 @@ RHUI deployment with the following hosts running RHEL 7:
 * one HAProxy instance
 * one client instance; it can be running RHEL 6, 7, or 8, regadless of the RHEL version on the RHUA
 * one atomic client instance
-* one test instance
+* one test instance; it can alternatively be running RHEL 8
 
 See the [RHUI deployment readme file ](https://github.com/RedHatQE/rhui3-automation/blob/master/deploy/README.md) for details.
 

--- a/tests/bash_completion/rhuitests
+++ b/tests/bash_completion/rhuitests
@@ -1,7 +1,7 @@
 #/bin/bash
 _rhuitests_completions() {
   case ${#COMP_WORDS[@]} in
-    2) COMPREPLY=($(compgen -W "$(echo all client ; ls /usr/share/rhui3_tests_lib/rhui3_tests/ | grep -v pyc$ | sed 's/^test_\(.*\)\.py$/\1/')" -- "${COMP_WORDS[1]}")) ;;
+    2) COMPREPLY=($(compgen -W "$(echo all client ; ls $(rhuitestdir) | egrep -v pyc\|__$ | sed 's/^test_\(.*\)\.py$/\1/')" -- "${COMP_WORDS[1]}")) ;;
     3) COMPREPLY=($(compgen -W "quiet" -- "${COMP_WORDS[2]}")) ; return ;;
     *) return ;;
   esac

--- a/tests/rhui3_tests/test_atomic_client.py
+++ b/tests/rhui3_tests/test_atomic_client.py
@@ -37,7 +37,7 @@ class TestClient(object):
         except socket.error:
             self.ah_exists = False
 
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
 
         self.atomic_repo_name = doc["atomic_repo"]["name"]

--- a/tests/rhui3_tests/test_client_management.py
+++ b/tests/rhui3_tests/test_client_management.py
@@ -60,7 +60,7 @@ class TestClient(object):
             raise RuntimeError("No custom RPMs to test in %s" % CUSTOM_RPMS_DIR)
         self.version = Util.get_rhel_version(CLI)["major"]
         arch = Util.get_arch(CLI)
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:
                 self.yum_repo_name = doc["yum_repos"][self.version][arch]["name"]

--- a/tests/rhui3_tests/test_cmdline.py
+++ b/tests/rhui3_tests/test_cmdline.py
@@ -40,7 +40,7 @@ class TestCLI(object):
     '''
 
     def __init__(self):
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
 
         self.yum_repo_names = [doc["CLI_repo1"]["name"], doc["CLI_repo2"]["name"]]

--- a/tests/rhui3_tests/test_containers.py
+++ b/tests/rhui3_tests/test_containers.py
@@ -46,7 +46,7 @@ class TestClient(object):
 
         arch = Util.get_arch(CLI)
 
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
 
         try:

--- a/tests/rhui3_tests/test_eus_cmd.py
+++ b/tests/rhui3_tests/test_eus_cmd.py
@@ -39,7 +39,7 @@ class TestEUSCLI(object):
     def __init__(self):
         self.cli_version = Util.get_rhel_version(CLI)["major"]
         arch = Util.get_arch(CLI)
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:
                 self.repo_id = doc["EUS_repos"][self.cli_version]["id"]

--- a/tests/rhui3_tests/test_repo_management.py
+++ b/tests/rhui3_tests/test_repo_management.py
@@ -36,7 +36,7 @@ class TestRepo(object):
         # Test the RHEL-6 repo for a change
         version = 6
         arch = "x86_64"
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:
                 self.yum_repo_name = doc["yum_repos"][version][arch]["name"]

--- a/tests/rhui3_tests/test_subscription.py
+++ b/tests/rhui3_tests/test_subscription.py
@@ -19,7 +19,7 @@ class TestSubscription(object):
     """class for tests for subscription registration in RHUI"""
 
     def __init__(self):
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             self.subscriptions = doc["subscriptions"]
 

--- a/tests/rhui3_tests/test_sync_management.py
+++ b/tests/rhui3_tests/test_sync_management.py
@@ -26,7 +26,7 @@ class TestSync(object):
         # Test the RHEL-7 ARM-64 repo for a change
         version = 7
         arch = "aarch64"
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:
                 self.yum_repo_name = doc["yum_repos"][version][arch]["name"]

--- a/tests/rhui3_tests/test_updateinfo.py
+++ b/tests/rhui3_tests/test_updateinfo.py
@@ -39,7 +39,7 @@ class TestClient(object):
     def __init__(self):
         self.arch = Util.get_arch(CLI)
         self.version = Util.get_rhel_version(CLI)["major"]
-        with open("/usr/share/rhui3_tests_lib/config/tested_repos.yaml") as configfile:
+        with open("/etc/rhui3_tests/tested_repos.yaml") as configfile:
             doc = yaml.load(configfile)
             try:
                 self.test = doc["updateinfo"][self.version][self.arch]

--- a/tests/scripts/rhuitestdir
+++ b/tests/scripts/rhuitestdir
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Find and print the path to the directory containing the RHUI tests.
+# This is needed because the path differs in RHEL 7, in RHEL 8, and if using RHSCL.
+
+base_dir=$(dirname $(dirname $(readlink -f $BASH_SOURCE)))
+echo $base_dir/share/rhui3_tests_lib/rhui3_tests

--- a/tests/scripts/rhuitests
+++ b/tests/scripts/rhuitests
@@ -3,7 +3,7 @@
 # Client tests will run on all cliN.example.com machines found in /etc/hosts,
 # unless a specific hostname is defined in the RHUICLI environment variable.
 
-tests_dir=/usr/share/rhui3_tests_lib/rhui3_tests
+tests_dir=$(rhuitestdir)
 if ! test -d $tests_dir; then
   echo "Cannot proceed: $tests_dir does not exist."
   exit 1

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -11,7 +11,7 @@ from setuptools import setup
 REQUIREMENTS = ['nose>=1.3.0', 'pytoml', 'requests', 'stitches>=0.12']
 
 DATAFILES = [('share/rhui3_tests_lib/rhui3_tests', glob('rhui3_tests/test_*.py')),
-             ('share/rhui3_tests_lib/config', ['rhui3_tests/tested_repos.yaml']),
+             ('/etc/rhui3_tests/', ['rhui3_tests/tested_repos.yaml']),
              ('/etc/bash_completion.d/', ['bash_completion/rhuitests'])]
 
 setup(name='rhui3_tests_lib',


### PR DESCRIPTION
With this commit, one can create a stack with a test machine running RHEL 8.

Lots of related changes had to be made because of the differences in the possible installations in RHEL 7, RHEL 7 + SCL, or RHEL 8. SSH key generation had to be modified because of the issue described [here](https://bugs.launchpad.net/ubuntu/+source/paramiko/+bug/1808194); this change is backward compatible so the key is usable in RHEL 6+. (I originally considered working that around by using ed25519, but that would break RHEL-6 client testing.) Lastly (though displayed first in the commit), the platform-python symlink is needed so that the public key can be stored on a RHEL-6 client by the Ansible task delegated from the RHEL-8 test machine.

All of this is optional, non-default, and doesn't break RHEL-7 test machines.