### PR TITLE
make changes for RHUI 3.1.3

### DIFF
--- a/deploy/roles/tests/tasks/main.yml
+++ b/deploy/roles/tests/tasks/main.yml
@@ -78,10 +78,10 @@
   tags: tests
 
 - name: upload Red Hat credentials
-  copy: src="{{ rhaccount }}" dest=/tmp/extra_rhui_files/rhaccount.sh
+  copy: src="{{ credentials }}" dest=/tmp/extra_rhui_files/credentials.conf
   delegate_to: "{{ item }}"
   with_items: "{{ groups['RHUA']|default([]) }}"
-  when: rhaccount is defined
+  when: credentials is defined
   tags: tests
 
 - name: prevent systemd-tmpfiles from purging the directory with the uploaded files

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -18,7 +18,8 @@ CFG_FILE = "~/.rhui3-automation.cfg"
 R3A_CFG = RawConfigParser()
 R3A_CFG.read(expanduser(CFG_FILE))
 
-PRS = argparse.ArgumentParser(description="Run the RHUI 3 Automation playbook to deploy RHUI.")
+PRS = argparse.ArgumentParser(description="Run the RHUI 3 Automation playbook to deploy RHUI.",
+                              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 PRS.add_argument("inventory",
                  help="inventory file; typically hosts_*.cfg created by create-cf-stack.py",
                  nargs="?")
@@ -36,9 +37,9 @@ PRS.add_argument("--extra-files",
                  help="ZIP file with extra files",
                  default="~/RHUI/extra_files.zip",
                  metavar="file")
-PRS.add_argument("--rhaccount",
-                 help="configuration file with extra Red Hat account data",
-                 default="~/RHUI/rhaccount.sh",
+PRS.add_argument("--creds",
+                 help="configuration file with credentials",
+                 default="~/RHUI/credentials.conf",
                  metavar="file")
 PRS.add_argument("--tests",
                  help="RHUI test to run",
@@ -91,10 +92,10 @@ if exists(expanduser(ARGS.extra_files)):
 else:
     print("%s does not exist, ignoring" % ARGS.extra_files)
 
-if exists(expanduser(ARGS.rhaccount)):
-    EVARS += " rhaccount=%s" % ARGS.rhaccount
+if exists(expanduser(ARGS.creds)):
+    EVARS += " credentials=%s" % ARGS.creds
 else:
-    print("%s does not exist, ignoring" % ARGS.rhaccount)
+    print("%s does not exist, ignoring" % ARGS.creds)
 
 # see if the configuration contains templates for RHEL Beta baseurls;
 # if so, expand them

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,32 +35,37 @@ In addition, you need a ZIP file with the following files in the root of the arc
 
 The main and Atomic certificates must not be expired. Expiration is first checked for the "empty", "incompatible", and "partially invalid" certificates, and the tests that use them are skipped if the given certificate has already expired.
 
-Lastly, in order for the subscription test to be able to run, you need a file with valid Red Hat credentials allowing access to RHUI. The file must look like this:
+Lastly, in order for several test to be able to run, you need a file with valid Red Hat CCSP credentials and Quay.io credentials. The file must look like this:
 
 ```
-SM_USERNAME=login
-SM_PASSWORD=password
+[rh]
+username=YOUR_RH_USERNAME
+password=YOUR_RH_PASSWORD
+
+[quay]
+username=YOUR_QUAY_USERNAME
+password=YOUR_QUAY_PASSWORD
 ```
 
-Replace `login` with your Red Hat login and `password` with your Red Hat password. Save the file in an appropriate location and give it an appropriate name; for example, `rhaccount.sh`. You can then keep the file this way if you are not worried that someone else could read it, or you can encrypt it using Ansible. To encrypt the file, use the following command in the directory holding the file:
+Set the user names and passwords. Save the file in an appropriate location and give it an appropriate name; for example, `credentials.conf`. You can then keep the file this way if you are not worried that someone else could read it, or you can encrypt it using Ansible. To encrypt the file, use the following command in the directory holding the file:
 
-`ansible-vault encrypt rhaccount.sh`
+`ansible-vault encrypt credentials.conf`
 
 Enter an appropriate encryption password when prompted.
 
 Usage
 --------
-You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instances in the `[CLI]` and `[ATOMIC_CLI]` sections of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the `--extra-vars` switch with the required ZIP file as a parameter of the `extra-files` option, the required credentials file as a parameter of the `rhaccount` option, and the `tests` variable with `all`, `client`, or a test name as its parameter; the test name is the part of the file name in the `rhui3_tests` directory between `test` and the extension. If the credentials file is encrypted, you will have to either provide the encryption password interactively or store it in a separate file (however, if someone reads that file, they will be able to read your Red Hat credentials, too, so be careful where you store the file).
+You can include the test stage in a RHUI 3 deployment by providing the address of your test instance in the `[TEST]` section and the address of your client instances in the `[CLI]` and `[ATOMIC_CLI]` sections of the `hosts.cfg` file. Alternatively, you can install and run the tests at any time after a RHUI 3 deployment by adding (or uncommenting) the `[TEST]`section and running `ansible-playbook` again. Either way, the `ansible-playbook` command line must contain the `--extra-vars` switch with the required ZIP file as a parameter of the `extra-files` option, the required credentials file as a parameter of the `credentials` option, and the `tests` variable with `all`, `client`, or a test name as its parameter; the test name is the part of the file name in the `rhui3_tests` directory between `test` and the extension. If the credentials file is encrypted, you will have to either provide the encryption password interactively or store it in a separate file (however, if someone reads that file, they will be able to read your Red Hat credentials, too, so be careful where you store the file).
 
 To install _and run the whole test suite_ as part of the initial deployment or after a completed deployment, use either the following command if you would like to enter the encryption password by hand:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh tests=all" --ask-vault-pass`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip credentials=~/Path/To/credentials.conf tests=all" --ask-vault-pass`
 
 Or the following command if you have stored the encryption password in a separate file and you only want to run the client tests:
 
-`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip rhaccount=~/Path/To/rhaccount.sh tests=client" --vault-password-file ~/Path/To/The/File/With/The/password`
+`ansible-playbook -i ~/pathto/hosts.cfg deploy/site.yml --extra-vars "rhui_iso=~/Path/To/Your/RHUI.iso extra_files=~/Path/To/Your/file.zip credentials=~/Path/To/credentials.conf tests=client" --vault-password-file ~/Path/To/The/File/With/The/password`
 
-Beware, regardless of the command you use, the credentials file will be stored on the RHUA node, _unencrypted_, as `/tmp/extra_rhui_files/rhaccount.sh`.
+Beware, regardless of the command you use, the credentials file will be stored on the RHUA node, _unencrypted_, as `/tmp/extra_rhui_files/credentials.conf`.
 
 Provide any other optional variables described in the RHUI deployment Readme as needed.
 

--- a/tests/rhui3_tests/tested_repos.yaml
+++ b/tests/rhui3_tests/tested_repos.yaml
@@ -66,6 +66,11 @@ container_rhel7:
         name: "rhel7-aarch64"
         id: "rhel7-arm64-from-rhui"
         displayname: "RHEL 7 ARM64"
+container_alt:
+    quay:
+        name: "pusher/oauth2_proxy"
+    docker:
+        name: "library/alpine"
 EUS_repos:
     6:
         id: "rhel-sap-hana-for-rhel-6-server-eus-rhui-rpms-6.7-x86_64"

--- a/tests/rhui3_tests_lib/subscription.py
+++ b/tests/rhui3_tests_lib/subscription.py
@@ -4,18 +4,17 @@ import re
 
 from stitches.expect import Expect
 
+from rhui3_tests_lib.helpers import Helpers
+
 class RHSMRHUI(object):
     """Subscription management for RHUI"""
     @staticmethod
-    def register_system(connection, alt_rhaccount_file=""):
+    def register_system(connection):
         """register with RHSM"""
-        rhaccount_file = alt_rhaccount_file or "/tmp/extra_rhui_files/rhaccount.sh"
-        if connection.recv_exit_status("test -f %s" % rhaccount_file):
-            raise OSError("%s does not exist" % rhaccount_file)
+        username, password = Helpers.get_credentials(connection)
         Expect.expect_retval(connection,
-                             "source %s && " % rhaccount_file +
                              "subscription-manager register --type=rhui " +
-                             "--username=$SM_USERNAME --password=$SM_PASSWORD",
+                             "--username=%s --password=%s" % (username, password),
                              timeout=40)
 
     @staticmethod

--- a/tests/rhui3_tests_lib/util.py
+++ b/tests/rhui3_tests_lib/util.py
@@ -267,3 +267,10 @@ class Util(object):
         fetch a file from the remote host
         '''
         connection.sftp.get(source, dest)
+
+    @staticmethod
+    def safe_pulp_repo_name(name):
+        '''
+        replace prohibited characters in repo names with safe ones (as per rhui-manager)
+        '''
+        return name.replace("/", "_").replace(".", "_")


### PR DESCRIPTION
RHUI 3.1.3 adds support for authentication when syncing containers and the ability to sync from any given registry, with registry.redhat.io as the default. This commit allows rhui3-automation to test these features.