### PR TITLE
avoid "dictionary changed size during iteration" with Python 3.7

### DIFF
--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -481,8 +481,8 @@ for i in range(1, args.haproxy + 1):
 if args.vpcid and args.subnetid:
     # Setting VpcId and SubnetId
     json_dict['Outputs'] = {}
-    for key in json_dict['Resources'].keys():
-        # We'll be changing dictionary so .keys() is required here!
+    for key in list(json_dict['Resources']):
+        # We'll be changing dictionary so retyping to a list is required to ensure compatibility with Python 3.7+.
         if json_dict['Resources'][key]['Type'] == 'AWS::EC2::SecurityGroup':
             json_dict['Resources'][key]['Properties']['VpcId'] = args.vpcid
         elif json_dict['Resources'][key]['Type'] == 'AWS::EC2::Instance':


### PR DESCRIPTION
With the original code, one could get:

```
$ ./scripts/create-cf-stack.py --name foo --vpcid abc --subnetid 123 --dry
Traceback (most recent call last):
  File "./scripts/create-cf-stack.py", line 485, in <module>
    for key in json_dict['Resources']:
RuntimeError: dictionary changed size during iteration
```