### PR TITLE
sanity-check the created inventory file

### DIFF
--- a/scripts/create-cf-stack.py
+++ b/scripts/create-cf-stack.py
@@ -819,6 +819,18 @@ for instance in instances_detail:
 print('# --- instances created ---')
 yaml.dump(result, sys.stdout)
 print('# --- stack data saved in %s ---' % outfile)
+# sometimes a hostname can't be obtained in time and doesn't appear in the file; check the file
+# (basically, if a line starts with the space character, it's a problem; report the line number)
+outfile_ok = True
+with open(outfile) as outfile_fd:
+    saved_lines = outfile_fd.readlines()
+    for index, text in enumerate(saved_lines):
+        if text.startswith(' '):
+            print('Missing hostname on line %s!' % (index + 1))
+            outfile_ok = False
+    if not outfile_ok:
+        print('Fix the file manually, or delete the stack and try again.')
+        sys.exit(2)
 # miserable hack --- cannot make paramiko not hang upon exit
 # [revised in February 2017] not necessary anymore
 #import os


### PR DESCRIPTION
Strangely, sometimes the public hostname of a RHUI node isn't known when the stack data is being written to the inventory file. The data is then missing the hostname, which makes the file unusable by `ansible-playbook`. This commit adds a test that works as follows:

```
...
# --- stack data saved in hosts_gluster_test2.cfg ---
Missing hostname on line 2!
Missing hostname on line 15!
Fix the file manually, or delete the stack and try again.
```
Also, when this happens, the exit code is 2, which can be caught by a parent script running the stack creation script (or anyone else who depends on the success of the stack creation before proceeding).

Note: the text doesn't say _how_ to fix the file manually. For the record, you can, for example, review the stack instances on the EC2 Dashboard, where the public hostnames _should_ appear eventually.

Needless to say, this is a workaround. It would be great if the public hostnames were known before the inventory file is saved. Ideas are welcome.